### PR TITLE
Change RetentionLevel.SOURCE to RetentionLevel.CLASS to work around a bu...

### DIFF
--- a/src/main/java/org/inferred/freebuilder/FreeBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/FreeBuilder.java
@@ -16,8 +16,6 @@
 package org.inferred.freebuilder;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -53,6 +51,5 @@ import java.lang.annotation.Target;
  * <a href="http://freebuilder.inferred.org/">Full documentation at freebuilder.inferred.org</a>
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
 public @interface FreeBuilder {}
 


### PR DESCRIPTION
Change RetentionLevel.SOURCE to RetentionLevel.CLASS on the @FreeBuilder annotation to work around a bug in Eclipse's incremental compilation.

This commit fixes #28 