### PR TITLE
Output a useful error, and generate meaningful code, if the user's Builder class is not static

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -143,9 +143,7 @@ class Analyser {
     return new Metadata.Builder(elements)
         .setType(type)
         .setBuilder(builder.or(generatedBuilder))
-        .setBuilderFactory(builder.isPresent()
-            ? BuilderFactory.from(builder.get())
-            : Optional.of(NO_ARGS_CONSTRUCTOR))
+        .setBuilderFactory(builderFactory(builder))
         .setGeneratedBuilder(generatedBuilder)
         .setValueType(generatedBuilder.createNestedClass("Value"))
         .setPartialType(generatedBuilder.createNestedClass("Partial"))
@@ -325,6 +323,17 @@ class Analyser {
     }
 
     return userClass;
+  }
+
+  private Optional<BuilderFactory> builderFactory(Optional<TypeElement> builder) {
+    if (!builder.isPresent()) {
+      return Optional.of(NO_ARGS_CONSTRUCTOR);
+    }
+    if (!builder.get().getModifiers().contains(Modifier.STATIC)) {
+      messager.printMessage(ERROR, "Builder must be static on @FreeBuilder types", builder.get());
+      return Optional.absent();
+    }
+    return BuilderFactory.from(builder.get());
   }
 
   private Map<String, Property> findProperties(

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -962,6 +962,26 @@ public class AnalyserTest {
   }
 
   @Test
+  public void nonStaticBuilder() throws CannotGenerateCodeException {
+    Metadata dataType = analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public abstract String getName();",
+        "  public class Builder extends DataType_Builder {}",
+        "}"));
+    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+    assertThat(properties.keySet()).containsExactly("name");
+    assertEquals("java.lang.String", properties.get("name").getType().toString());
+    assertNull(properties.get("name").getBoxedType());
+    assertEquals("NAME", properties.get("name").getAllCapsName());
+    assertEquals("Name", properties.get("name").getCapitalizedName());
+    assertEquals("getName", properties.get("name").getGetterName());
+    assertThat(dataType.getBuilderFactory()).isAbsent();
+    assertThat(messager.getMessagesByElement().asMap()).containsEntry(
+        "Builder", ImmutableList.of("[ERROR] Builder must be static on @FreeBuilder types"));
+  }
+
+  @Test
   public void genericType() {
     TypeElement dataType = model.newType(
         "package com.example;",


### PR DESCRIPTION
Fixes #16.