### PR TITLE
Fix #19: Underriding breaks partials

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -27,17 +27,17 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
+import java.util.Map;
 
-import org.inferred.freebuilder.processor.Analyser;
-import org.inferred.freebuilder.processor.DefaultPropertyFactory;
-import org.inferred.freebuilder.processor.Metadata;
-import org.inferred.freebuilder.processor.MethodIntrospector;
+import javax.annotation.Generated;
+import javax.annotation.Nullable;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.Metadata.StandardMethod;
+import org.inferred.freebuilder.processor.Metadata.UnderrideLevel;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
 import org.inferred.freebuilder.processor.util.ImpliedClass;
 import org.inferred.freebuilder.processor.util.testing.FakeMessager;
@@ -48,12 +48,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.Map;
-
-import javax.annotation.Generated;
-import javax.annotation.Nullable;
-import javax.lang.model.element.PackageElement;
-import javax.lang.model.element.TypeElement;
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /** Unit tests for {@link Analyser}. */
 @RunWith(JUnit4.class)
@@ -632,7 +630,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).containsExactly(StandardMethod.EQUALS);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE,
+        StandardMethod.HASH_CODE, UnderrideLevel.ABSENT,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap())
         .containsEntry("equals", ImmutableList.of(
             "[ERROR] hashCode and equals must be implemented together on @FreeBuilder types"));
@@ -651,7 +652,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).containsExactly(StandardMethod.HASH_CODE);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.ABSENT,
+        StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap())
         .containsEntry("hashCode", ImmutableList.of(
             "[ERROR] hashCode and equals must be implemented together on @FreeBuilder types"));
@@ -673,8 +677,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods())
-        .containsExactly(StandardMethod.HASH_CODE, StandardMethod.EQUALS);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE,
+        StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -691,7 +697,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).containsExactly(StandardMethod.TO_STRING);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.ABSENT,
+        StandardMethod.HASH_CODE, UnderrideLevel.ABSENT,
+        StandardMethod.TO_STRING, UnderrideLevel.OVERRIDEABLE));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -714,8 +723,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods())
-        .containsExactly(StandardMethod.EQUALS, StandardMethod.HASH_CODE, StandardMethod.TO_STRING);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE,
+        StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE,
+        StandardMethod.TO_STRING, UnderrideLevel.OVERRIDEABLE));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -732,7 +743,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).containsExactly(StandardMethod.EQUALS);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.FINAL,
+        StandardMethod.HASH_CODE, UnderrideLevel.ABSENT,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap())
         .containsEntry("equals", ImmutableList.of(
             "[ERROR] hashCode and equals must be implemented together on @FreeBuilder types"));
@@ -751,7 +765,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).containsExactly(StandardMethod.HASH_CODE);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.ABSENT,
+        StandardMethod.HASH_CODE, UnderrideLevel.FINAL,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap())
         .containsEntry("hashCode", ImmutableList.of(
             "[ERROR] hashCode and equals must be implemented together on @FreeBuilder types"));
@@ -773,8 +790,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods())
-        .containsExactly(StandardMethod.HASH_CODE, StandardMethod.EQUALS);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.FINAL,
+        StandardMethod.HASH_CODE, UnderrideLevel.FINAL,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -791,7 +810,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).containsExactly(StandardMethod.TO_STRING);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.ABSENT,
+        StandardMethod.HASH_CODE, UnderrideLevel.ABSENT,
+        StandardMethod.TO_STRING, UnderrideLevel.FINAL));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -814,8 +836,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods())
-        .containsExactly(StandardMethod.EQUALS, StandardMethod.HASH_CODE, StandardMethod.TO_STRING);
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.FINAL,
+        StandardMethod.HASH_CODE, UnderrideLevel.FINAL,
+        StandardMethod.TO_STRING, UnderrideLevel.FINAL));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -831,7 +855,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).isEmpty();
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.ABSENT,
+        StandardMethod.HASH_CODE, UnderrideLevel.ABSENT,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -847,7 +874,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).isEmpty();
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.ABSENT,
+        StandardMethod.HASH_CODE, UnderrideLevel.ABSENT,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 
@@ -863,7 +893,10 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
-    assertThat(metadata.getUnderriddenMethods()).isEmpty();
+    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+        StandardMethod.EQUALS, UnderrideLevel.ABSENT,
+        StandardMethod.HASH_CODE, UnderrideLevel.ABSENT,
+        StandardMethod.TO_STRING, UnderrideLevel.ABSENT));
     assertThat(messager.getMessagesByElement().asMap()).isEmpty();
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -927,7 +927,96 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testUnderriding_hashCodeEqualsAndToString() {
+  public void testUnderriding_hashCodeAndEquals() {
+    behaviorTester
+        .with(new Processor())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public abstract class Person {")
+            .addLine("  public abstract String getName();")
+            .addLine("  public abstract int getAge();")
+            .addLine("")
+            .addLine("  @Override public boolean equals(Object other) {")
+            .addLine("    return (other instanceof Person)")
+            .addLine("        && getName().equals(((Person) other).getName());")
+            .addLine("  }")
+            .addLine("  @Override public int hashCode() {")
+            .addLine("    return getName().hashCode();")
+            .addLine("  }")
+            .addLine("")
+            .addLine("  public static class Builder extends Person_Builder {}")
+            .addLine("}")
+            .build())
+        // If hashCode and equals are not final, they are overridden to respect Partial behavior.
+        .with(new TestBuilder()
+            .addImport(EqualsTester.class)
+            .addImport("com.example.Person")
+            .addLine("new EqualsTester()")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Bill\").setAge(10).build(),")
+            .addLine("        new Person.Builder().setName(\"Bill\").setAge(18).build())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Ted\").setAge(10).build(),")
+            .addLine("        new Person.Builder().setName(\"Ted\").setAge(18).build())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Bill\").setAge(10).buildPartial(),")
+            .addLine("        new Person.Builder().setName(\"Bill\").setAge(10).buildPartial())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Bill\").setAge(18).buildPartial())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Bill\").buildPartial())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Ted\").setAge(10).buildPartial(),")
+            .addLine("        new Person.Builder().setName(\"Ted\").setAge(10).buildPartial())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Ted\").setAge(18).buildPartial())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setName(\"Ted\").buildPartial())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setAge(10).buildPartial())")
+            .addLine("    .addEqualityGroup(")
+            .addLine("        new Person.Builder().setAge(18).buildPartial())")
+            .addLine("    .testEquals();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testUnderriding_toString() {
+    behaviorTester
+        .with(new Processor())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public abstract class Person {")
+            .addLine("  public abstract String getName();")
+            .addLine("  public abstract int getAge();")
+            .addLine("")
+            .addLine("  @Override public String toString() {")
+            .addLine("    return getName() + \" (age \" + getAge() + \")\";")
+            .addLine("  }")
+            .addLine("")
+            .addLine("  public static class Builder extends Person_Builder {}")
+            .addLine("}")
+            .build())
+        // If toString is not final, it is overridden in Partial.
+        .with(new TestBuilder()
+            .addLine("com.example.Person p1 = new com.example.Person.Builder()")
+            .addLine("    .setName(\"Bill\")")
+            .addLine("    .setAge(18)")
+            .addLine("    .build();")
+            .addLine("com.example.Person p2 = new com.example.Person.Builder()")
+            .addLine("    .setName(\"Bill\")")
+            .addLine("    .buildPartial();")
+            .addLine("assertEquals(\"Bill (age 18)\", p1.toString());")
+            .addLine("assertEquals(\"partial Person{name=Bill}\", p2.toString());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testUnderriding_finalHashCodeEqualsAndToString() {
     behaviorTester
         .with(new Processor())
         .with(new SourceBuilder()
@@ -955,7 +1044,7 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testUnderriding_hashCodeAndEquals() {
+  public void testUnderriding_finalHashCodeAndEquals() {
     behaviorTester
         .with(new Processor())
         .with(new SourceBuilder()
@@ -993,7 +1082,7 @@ public class ProcessorTest {
   }
 
   @Test
-  public void testUnderriding_toString() {
+  public void testUnderriding_finalToString() {
     behaviorTester
         .with(new Processor())
         .with(new SourceBuilder()


### PR DESCRIPTION
Override user-provided toString, equals and hashCode (if they are non-final) to ensure correct behavior of Partials. This fixes #19.

@FreeBuilder partials never compare equal to a value object, even if they have the same field values. There may be cases where the user really wants a partial to compare equal to a final value, in which case they will need to declare their methods final and Do It Themselves. There doesn't seem to be a safe way to call the user's equals method and "fall back" to the default behavior otherwise, because we don't know how they've implemented hashCode, so I don't think we can keep to the hashCode/equals contract.