### PR TITLE
Fix issue #17: Getter method name check is too broad [re-request]

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -349,6 +349,20 @@ public class AnalyserTest {
   }
 
   @Test
+  public void nonAbstractMethodNamedIssue() throws CannotGenerateCodeException {
+    Metadata dataType = analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public boolean issue() {",
+        "    return true;",
+        "  }",
+        "  public static class Builder extends DataType_Builder {}",
+        "}"));
+    assertThat(dataType.getProperties()).isEmpty();
+    assertThat(messager.getMessagesByElement().keys()).isEmpty();
+  }
+
+  @Test
   public void voidGetter() throws CannotGenerateCodeException {
     Metadata dataType = analyser.analyse(model.newType(
         "package com.example;",

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -406,6 +406,81 @@ public class AnalyserTest {
   }
 
   @Test
+  public void abstractMethodNamedGet() throws CannotGenerateCodeException {
+    Metadata dataType = analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public abstract String get();",
+        "  public static class Builder extends DataType_Builder {}",
+        "}"));
+    assertThat(dataType.getProperties()).isEmpty();
+    assertThat(messager.getMessagesByElement().keys()).containsExactly("get");
+    assertThat(messager.getMessagesByElement().get("get"))
+        .containsExactly("[ERROR] Only getter methods (starting with 'get' or 'is') may be declared"
+            + " abstract on @FreeBuilder types");
+  }
+
+  @Test
+  public void abstractMethodNamedGetter() throws CannotGenerateCodeException {
+    Metadata dataType = analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public abstract String getter();",
+        "  public static class Builder extends DataType_Builder {}",
+        "}"));
+    assertThat(dataType.getProperties()).isEmpty();
+    assertThat(messager.getMessagesByElement().keys()).containsExactly("getter");
+    assertThat(messager.getMessagesByElement().get("getter"))
+        .containsExactly("[ERROR] Getter methods cannot have a lowercase character immediately"
+            + " after the 'get' prefix on @FreeBuilder types (did you mean 'getTer'?)");
+  }
+
+  @Test
+  public void abstractMethodNamedIssue() throws CannotGenerateCodeException {
+    Metadata dataType = analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public abstract String issue();",
+        "  public static class Builder extends DataType_Builder {}",
+        "}"));
+    assertThat(dataType.getProperties()).isEmpty();
+    assertThat(messager.getMessagesByElement().keys()).containsExactly("issue");
+    assertThat(messager.getMessagesByElement().get("issue"))
+        .containsExactly("[ERROR] Getter methods cannot have a lowercase character immediately"
+            + " after the 'is' prefix on @FreeBuilder types (did you mean 'isSue'?)");
+  }
+
+  @Test
+  public void abstractMethodNamedGetürkt() throws CannotGenerateCodeException {
+    Metadata dataType = analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public abstract String getürkt();",
+        "  public static class Builder extends DataType_Builder {}",
+        "}"));
+    assertThat(dataType.getProperties()).isEmpty();
+    assertThat(messager.getMessagesByElement().keys()).containsExactly("getürkt");
+    assertThat(messager.getMessagesByElement().get("getürkt"))
+        .containsExactly("[ERROR] Getter methods cannot have a lowercase character immediately"
+            + " after the 'get' prefix on @FreeBuilder types (did you mean 'getÜrkt'?)");
+  }
+
+  @Test
+  public void abstractMethodNamedIs() throws CannotGenerateCodeException {
+    Metadata dataType = analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public abstract boolean is();",
+        "  public static class Builder extends DataType_Builder {}",
+        "}"));
+    assertThat(dataType.getProperties()).isEmpty();
+    assertThat(messager.getMessagesByElement().keys()).containsExactly("is");
+    assertThat(messager.getMessagesByElement().get("is"))
+        .containsExactly("[ERROR] Only getter methods (starting with 'get' or 'is') may be declared"
+            + " abstract on @FreeBuilder types");
+  }
+
+  @Test
   public void mixedValidAndInvalidGetters() throws CannotGenerateCodeException {
     Metadata dataType = analyser.analyse(model.newType(
         "package com.example;",


### PR DESCRIPTION
Change the Analyser to require a non-lowercase character immediately following the 'get'/'is' prefix on getter methods. This fixes #17.

Re-request of the accidentally-closed #31.