### PR TITLE
Run Model with encoding set to UTF-8.

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/Model.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/Model.java
@@ -345,7 +345,7 @@ public class Model {
             null,  // Writer
             fileManager,
             diagnostics,
-            ImmutableList.of("-proc:only"),
+            ImmutableList.of("-proc:only", "-encoding", "UTF-8"),
             null,  // Class names
             ImmutableList.of(bootstrapType));
         task.setProcessors(ImmutableList.of(new ElementCapturingProcessor()));


### PR DESCRIPTION
At the moment, the getürkt test fails under Maven (but passes in Eclipse).