### PR TITLE
Fix #28: not detecting jarred @FreeBuilder types

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
@@ -99,7 +99,7 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
       mergeFromBuilderMethod = MergeBuilderMethod.MERGE_DIRECTLY;
     } else {
       List<ExecutableElement> methods = FluentIterable
-          .from(builder.get().getEnclosedElements())
+          .from(config.getElements().getAllMembers(builder.get()))
           .filter(ExecutableElement.class)
           .filter(new IsCallableMethod())
           .toList();


### PR DESCRIPTION
Check inherited members of Builders for required methods (clear, etc.), not just direct members.

This fixes #28, where @FreeBuilder types pulled in from a jar rather than compiled in do not get detected as builders because the annotation is SOURCE-level only.