### PR TITLE
Cleaner test logs

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/MultisetPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MultisetPropertyFactoryTest.java
@@ -15,15 +15,13 @@
  */
 package org.inferred.freebuilder.processor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Iterator;
 
 import javax.tools.JavaFileObject;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.CompilationException;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
@@ -419,20 +417,14 @@ public class MultisetPropertyFactoryTest {
 
   @Test
   public void testAddVarargs_null_primitive() {
-    boolean caughtException = false;
-    try {
-      behaviorTester
-          .with(new Processor())
-          .with(MULTISET_PRIMITIVES_TYPE)
-          .with(new TestBuilder()
-              .addLine("new com.example.DataType.Builder().addItems(1, null);")
-              .build())
-          .runTest();
-    } catch (AssertionError e) {
-      caughtException = true;
-      assertEquals("Compilation failed", e.getMessage());
-    }
-    assertTrue("Expected exception", caughtException);
+    behaviorTester
+        .with(new Processor())
+        .with(MULTISET_PRIMITIVES_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder().addItems(1, null);")
+            .build());
+    thrown.expect(CompilationException.class);
+    behaviorTester.runTest();
   }
 
   @Test

--- a/src/test/java/org/inferred/freebuilder/processor/SetPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetPropertyFactoryTest.java
@@ -15,9 +15,6 @@
  */
 package org.inferred.freebuilder.processor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Iterator;
 import java.util.Set;
 
@@ -25,6 +22,7 @@ import javax.tools.JavaFileObject;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.CompilationException;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
@@ -327,20 +325,14 @@ public class SetPropertyFactoryTest {
 
   @Test
   public void testAddVarargs_null_primitive() {
-    boolean caughtException = false;
-    try {
-      behaviorTester
-          .with(new Processor())
-          .with(SET_PRIMITIVES_AUTO_BUILT_TYPE)
-          .with(new TestBuilder()
-              .addLine("new com.example.DataType.Builder().addItems(1, null);")
-              .build())
-          .runTest();
-    } catch (AssertionError e) {
-      caughtException = true;
-      assertEquals("Compilation failed", e.getMessage());
-    }
-    assertTrue("Expected exception", caughtException);
+    behaviorTester
+        .with(new Processor())
+        .with(SET_PRIMITIVES_AUTO_BUILT_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder().addItems(1, null);")
+            .build());
+    thrown.expect(CompilationException.class);
+    behaviorTester.runTest();
   }
 
   @Test

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
@@ -16,7 +16,6 @@
 package org.inferred.freebuilder.processor.util.testing;
 
 import static com.google.common.util.concurrent.Uninterruptibles.joinUninterruptibly;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -27,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.processing.Processor;
-import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
@@ -235,11 +233,8 @@ public class BehaviorTester {
     task.setProcessors(processors);
     boolean successful = task.call();
     if (!successful) {
-      for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
-        System.err.println(diagnostic);
-      }
+      throw new CompilationException(diagnostics.getDiagnostics());
     }
-    assertTrue("Compilation failed", successful);
   }
 
   private static JavaCompiler getCompiler() {

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTesterTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTesterTest.java
@@ -102,20 +102,13 @@ public class BehaviorTesterTest {
     assertTrue("Expected an AssertionError", caughtError);
   }
 
-  @Test
+  @Test(expected = CompilationException.class)
   public void failingCompilation_throwsAssertionError() {
-    boolean caughtError = false;
-    try {
-      behaviorTester
-          .with(new TestBuilder()
-              .addLine("jooblefish")
-              .build())
-          .runTest();
-    } catch (AssertionError e) {
-      caughtError = true;
-      assertEquals("Compilation failed", e.getMessage());
-    }
-    assertTrue("Expected an AssertionError", caughtError);
+    behaviorTester
+        .with(new TestBuilder()
+            .addLine("jooblefish")
+            .build())
+        .runTest();
   }
 
   @Test

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/CompilationException.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/CompilationException.java
@@ -1,0 +1,45 @@
+package org.inferred.freebuilder.processor.util.testing;
+
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * {@code CompilationException} is thrown when a
+ * {@link javax.tools.JavaCompiler.CompilationTask CompilationTask} fails, to capture any emitted
+ * {@link Diagnostic} instances.
+ */
+public class CompilationException extends RuntimeException {
+
+  private final ImmutableList<Diagnostic<? extends JavaFileObject>> diagnostics;
+
+  public CompilationException(List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+    this.diagnostics = ImmutableList.copyOf(diagnostics);
+  }
+
+  public CompilationException(CompilationException e) {
+    this(e.diagnostics);
+  }
+
+  @Override
+  public String getMessage() {
+    StringBuilder fullMessage = new StringBuilder("Compilation failed");
+    int i = 1;
+    for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics) {
+      fullMessage.append("\n    ").append(i++).append(") ")
+          .append(diagnostic.getMessage(Locale.getDefault()));
+      JavaFileObject source = diagnostic.getSource();
+      long line = diagnostic.getLineNumber();
+      if (source != null && line != Diagnostic.NOPOS) {
+        File sourceFile = new File(source.getName());
+        fullMessage.append(" (").append(sourceFile.getName()).append(":").append(line).append(")");
+      }
+    }
+    return fullMessage.toString();
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/ModelTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/ModelTest.java
@@ -149,6 +149,19 @@ public class ModelTest {
   }
 
   @Test
+  public void newElementAnnotatedWith_compilationError() {
+    thrown.expect(CompilationException.class);
+    model.newElementAnnotatedWith(
+        Deprecated.class,
+        "package foo.bar;",
+        "public class MyType {",
+        "  public class MyInnerType {",
+        "    public void doNothing() {",
+        "  }",
+        "}");
+  }
+
+  @Test
   public void newType_class() {
     TypeElement type = model.newType(
         "package foo.bar;",


### PR DESCRIPTION
Wrap compiler diagnostics in a new CompilationException, rather than dumping them to stderr. This makes test failures easier to diagnose, and also avoids polluting test logs with expected error messages.