### PR TITLE
Issue #29: Illegal code generated for Optional types with wildcards.

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/CodeGeneratorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/CodeGeneratorTest.java
@@ -621,12 +621,12 @@ public class CodeGeneratorTest {
         .addProperty(name
             .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
                 name.build(), "setName", "setNullableName", "clearName", string,
-                Optional.<TypeMirror>absent()))
+                Optional.<TypeMirror>absent(), false))
             .build())
         .addProperty(age
             .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
                 age.build(), "setAge", "setNullableAge", "clearAge", integer,
-                Optional.<TypeMirror>of(INT)))
+                Optional.<TypeMirror>of(INT), false))
             .build())
         .setPropertyEnum(generatedBuilder.nestedType("Property"))
         .setType(person)
@@ -1808,12 +1808,12 @@ public class CodeGeneratorTest {
         .addProperty(name
             .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
                 name.build(), "setName", "setNullableName", "clearName", string,
-                Optional.<TypeMirror>absent()))
+                Optional.<TypeMirror>absent(), false))
             .build())
         .addProperty(age
             .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
                 age.build(), "setAge", "setNullableAge", "clearAge", integer,
-                Optional.<TypeMirror>of(INT)))
+                Optional.<TypeMirror>of(INT), false))
             .build())
         .setPropertyEnum(generatedBuilder.nestedType("Property"))
         .setType(person)


### PR DESCRIPTION
Explicitly specify the type parameter of Optional.fromNullable if the type parameter contains a wildcard. In Java 7 and earlier, the generated code does not compile otherwise. This fixes #29.