### PR TITLE
Fix accidental aliasing of nested types in the user's class.

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Metadata.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata.java
@@ -69,6 +69,7 @@ public class Metadata extends ValueType {
   private final TypeReference valueType;
   private final TypeReference partialType;
   private final TypeReference propertyEnum;
+  private final ImmutableSet<TypeReference> visibleNestedTypes;
   private final ImmutableList<Property> properties;
   private final ImmutableMap<StandardMethod, UnderrideLevel> standardMethodUnderrides;
   private final boolean builderSerializable;
@@ -84,6 +85,7 @@ public class Metadata extends ValueType {
     this.valueType = builder.valueType;
     this.partialType = builder.partialType;
     this.propertyEnum = builder.propertyEnum;
+    this.visibleNestedTypes = ImmutableSet.copyOf(builder.visibleNestedTypes);
     this.properties = ImmutableList.copyOf(builder.properties);
     this.standardMethodUnderrides = ImmutableMap.copyOf(builder.standardMethodUnderrides);
     this.builderSerializable = builder.builderSerializable;
@@ -136,6 +138,14 @@ public class Metadata extends ValueType {
   /** Returns the partial value class that should be generated. */
   public TypeReference getPartialType() {
     return partialType;
+  }
+
+  /**
+   * Returns a set of nested types that will be visible in the generated class, either because they
+   * will be generated, or because they are present in a superclass.
+   */
+  public ImmutableSet<TypeReference> getVisibleNestedTypes() {
+    return visibleNestedTypes;
   }
 
   /** Returns the Property enum that may be generated. */
@@ -362,10 +372,11 @@ public class Metadata extends ValueType {
     fields.add("type", type.toString());
     fields.add("builder", hasBuilder() ? builder.toString() : null);
     fields.add("builderFactory", builderFactory);
-    fields.add("generatedBuilder", generatedBuilder.toString());
-    fields.add("valueType", valueType.toString());
-    fields.add("partialType", partialType.toString());
-    fields.add("propertyEnum", propertyEnum.toString());
+    fields.add("generatedBuilder", generatedBuilder);
+    fields.add("valueType", valueType);
+    fields.add("partialType", partialType);
+    fields.add("propertyEnum", propertyEnum);
+    fields.add("visibleNestedTypes", visibleNestedTypes);
     fields.add("properties", properties);
     fields.add("standardMethodUnderrides", standardMethodUnderrides);
     fields.add("builderSerializable", builderSerializable);
@@ -381,9 +392,10 @@ public class Metadata extends ValueType {
     private TypeElement builder;
     private BuilderFactory builderFactory;
     private TypeReference generatedBuilder;
-    public TypeReference valueType;
-    public TypeReference partialType;
-    public TypeReference propertyEnum;
+    private TypeReference valueType;
+    private TypeReference partialType;
+    private TypeReference propertyEnum;
+    private final Set<TypeReference> visibleNestedTypes = new LinkedHashSet<TypeReference>();
     private final List<Property> properties = new ArrayList<Property>();
     private final Map<StandardMethod, UnderrideLevel> standardMethodUnderrides = noUnderrides();
     private Boolean builderSerializable;
@@ -445,6 +457,18 @@ public class Metadata extends ValueType {
     /** Sets the property enum that may be generated.  */
     public Builder setPropertyEnum(TypeReference propertyEnum) {
       this.propertyEnum = propertyEnum;
+      return this;
+    }
+
+    /** Adds a nested type that will be visible in the generated class. */
+    public Builder addVisibleNestedType(TypeReference nestedType) {
+      this.visibleNestedTypes.add(nestedType);
+      return this;
+    }
+
+    /** Adds nested types that will be visible in the generated class. */
+    public Builder addAllVisibleNestedTypes(Iterable<TypeReference> nestedType) {
+      addAll(this.visibleNestedTypes, nestedType);
       return this;
     }
 

--- a/src/main/java/org/inferred/freebuilder/processor/Processor.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Processor.java
@@ -80,8 +80,7 @@ public class Processor extends AbstractProcessor {
             processingEnv.getElementUtils(),
             SourceLevel.from(processingEnv.getSourceVersion()),
             metadata.getGeneratedBuilder(),
-            ImmutableSet.of(
-                metadata.getPartialType(), metadata.getPropertyEnum(), metadata.getValueType()),
+            metadata.getVisibleNestedTypes(),
             type);
         try {
           codeGenerator.writeBuilderSource(code, metadata);

--- a/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
@@ -18,6 +18,10 @@ package org.inferred.freebuilder.processor.util;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleElementVisitor6;
+import javax.lang.model.util.SimpleTypeVisitor6;
 
 import com.google.common.base.Optional;
 
@@ -41,5 +45,53 @@ public class ModelUtils {
     }
     return Optional.absent();
   }
+
+  /** Returns {@code element} as a {@link TypeElement}, if it is one. */
+  public static Optional<TypeElement> maybeType(Element element) {
+    return TYPE_ELEMENT_VISITOR.visit(element);
+  }
+
+  /** Returns {@code type} as a {@link DeclaredType}, if it is one. */
+  public static Optional<DeclaredType> maybeDeclared(TypeMirror type) {
+    return DECLARED_TYPE_VISITOR.visit(type);
+  }
+
+  /** Returns the {@link TypeElement} corresponding to {@code type}, if there is one. */
+  public static Optional<TypeElement> maybeAsTypeElement(TypeMirror type) {
+    Optional<DeclaredType> declaredType = maybeDeclared(type);
+    if (declaredType.isPresent()) {
+      return maybeType(declaredType.get().asElement());
+    } else {
+      return Optional.absent();
+    }
+  }
+
+  private static final SimpleElementVisitor6<Optional<TypeElement>, ?> TYPE_ELEMENT_VISITOR =
+      new SimpleElementVisitor6<Optional<TypeElement>, Void>() {
+
+        @Override
+        public Optional<TypeElement> visitType(TypeElement e, Void p) {
+          return Optional.of(e);
+        }
+
+        @Override
+        protected Optional<TypeElement> defaultAction(Element e, Void p) {
+          return Optional.absent();
+        }
+      };
+
+  private static final SimpleTypeVisitor6<Optional<DeclaredType>, ?> DECLARED_TYPE_VISITOR =
+      new SimpleTypeVisitor6<Optional<DeclaredType>, Void>() {
+
+        @Override
+        public Optional<DeclaredType> visitDeclared(DeclaredType t, Void p) {
+          return Optional.of(t);
+        }
+
+        @Override
+        protected Optional<DeclaredType> defaultAction(TypeMirror e, Void p) {
+          return Optional.absent();
+        }
+      };
 }
 

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -80,16 +80,22 @@ public class AnalyserTest {
     Metadata metadata = analyser.analyse(dataType);
 
     TypeReference expectedBuilder = TypeReference.to("com.example", "DataType_Builder");
+    TypeReference partialType = expectedBuilder.nestedType("Partial");
+    TypeReference propertyType = expectedBuilder.nestedType("Property");
+    TypeReference valueType = expectedBuilder.nestedType("Value");
     Metadata expectedMetadata = new Metadata.Builder(model.elementUtils())
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
         .setBuilderSerializable(true)
         .setGeneratedBuilder(expectedBuilder)
         .setGwtCompatible(false)
         .setGwtSerializable(false)
-        .setPartialType(expectedBuilder.nestedType("Partial"))
-        .setPropertyEnum(expectedBuilder.nestedType("Property"))
+        .setPartialType(partialType)
+        .setPropertyEnum(propertyType)
         .setType(dataType)
-        .setValueType(expectedBuilder.nestedType("Value"))
+        .setValueType(valueType)
+        .addVisibleNestedType(partialType)
+        .addVisibleNestedType(propertyType)
+        .addVisibleNestedType(valueType)
         .build();
 
     assertEquals(expectedMetadata, metadata);
@@ -109,16 +115,22 @@ public class AnalyserTest {
     Metadata metadata = analyser.analyse(dataType);
 
     TypeReference expectedBuilder = TypeReference.to("com.example", "DataType_Builder");
+    TypeReference partialType = expectedBuilder.nestedType("Partial");
+    TypeReference propertyType = expectedBuilder.nestedType("Property");
+    TypeReference valueType = expectedBuilder.nestedType("Value");
     Metadata expectedMetadata = new Metadata.Builder(model.elementUtils())
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
         .setBuilderSerializable(true)
         .setGeneratedBuilder(expectedBuilder)
         .setGwtCompatible(false)
         .setGwtSerializable(false)
-        .setPartialType(expectedBuilder.nestedType("Partial"))
-        .setPropertyEnum(expectedBuilder.nestedType("Property"))
+        .setPartialType(partialType)
+        .setPropertyEnum(propertyType)
         .setType(dataType)
-        .setValueType(expectedBuilder.nestedType("Value"))
+        .setValueType(valueType)
+        .addVisibleNestedType(partialType)
+        .addVisibleNestedType(propertyType)
+        .addVisibleNestedType(valueType)
         .build();
 
     assertEquals(expectedMetadata, metadata);
@@ -1077,18 +1089,26 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
+    TypeElement concreteBuilder = model.typeElement("com.example.DataType.Builder");
     TypeReference expectedBuilder = TypeReference.to("com.example", "DataType_Builder");
+    TypeReference partialType = expectedBuilder.nestedType("Partial");
+    TypeReference propertyType = expectedBuilder.nestedType("Property");
+    TypeReference valueType = expectedBuilder.nestedType("Value");
     Metadata expectedMetadata = new Metadata.Builder(model.elementUtils())
-        .setBuilder(model.typeElement("com.example.DataType.Builder"))
+        .setBuilder(concreteBuilder)
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
         .setBuilderSerializable(false)
         .setGeneratedBuilder(expectedBuilder)
         .setGwtCompatible(false)
         .setGwtSerializable(false)
-        .setPartialType(expectedBuilder.nestedType("Partial"))
-        .setPropertyEnum(expectedBuilder.nestedType("Property"))
+        .setPartialType(partialType)
+        .setPropertyEnum(propertyType)
         .setType(dataType)
-        .setValueType(expectedBuilder.nestedType("Value"))
+        .setValueType(valueType)
+        .addVisibleNestedType(TypeReference.to(concreteBuilder))
+        .addVisibleNestedType(partialType)
+        .addVisibleNestedType(propertyType)
+        .addVisibleNestedType(valueType)
         .build();
 
     assertEquals(expectedMetadata, metadata);
@@ -1108,18 +1128,26 @@ public class AnalyserTest {
 
     Metadata metadata = analyser.analyse(dataType);
 
+    TypeElement concreteBuilder = model.typeElement("com.example.DataType.Builder");
     TypeReference expectedBuilder = TypeReference.to("com.example", "DataType_Builder");
+    TypeReference partialType = expectedBuilder.nestedType("Partial");
+    TypeReference propertyType = expectedBuilder.nestedType("Property");
+    TypeReference valueType = expectedBuilder.nestedType("Value");
     Metadata expectedMetadata = new Metadata.Builder(model.elementUtils())
-        .setBuilder(model.typeElement("com.example.DataType.Builder"))
+        .setBuilder(concreteBuilder)
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
         .setBuilderSerializable(false)
         .setGeneratedBuilder(expectedBuilder)
         .setGwtCompatible(false)
         .setGwtSerializable(false)
-        .setPartialType(expectedBuilder.nestedType("Partial"))
-        .setPropertyEnum(expectedBuilder.nestedType("Property"))
+        .setPartialType(partialType)
+        .setPropertyEnum(propertyType)
         .setType(dataType)
-        .setValueType(expectedBuilder.nestedType("Value"))
+        .setValueType(valueType)
+        .addVisibleNestedType(TypeReference.to(concreteBuilder))
+        .addVisibleNestedType(partialType)
+        .addVisibleNestedType(propertyType)
+        .addVisibleNestedType(valueType)
         .build();
 
     assertEquals(expectedMetadata, metadata);
@@ -1299,6 +1327,54 @@ public class AnalyserTest {
         .containsEntry("DataType", ImmutableList.of(
             "[NOTE] Add \"class Builder extends DataType_Builder {}\" to your interface "
                 + "to enable the @FreeBuilder API"));
+  }
+
+  @Test
+  public void valueTypeNestedClassesAddedToVisibleList() throws CannotGenerateCodeException {
+     TypeElement dataType = model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  DataType(int i) { }",
+        "  DataType() { }",
+        "  DataType(String s) { }",
+        "  public static class Builder extends DataType_Builder {}",
+        "  public interface Objects {}",
+        "}");
+
+    Metadata metadata = analyser.analyse(dataType);
+
+    assertThat(metadata.getVisibleNestedTypes()).containsExactly(
+        TypeReference.to("com.example", "DataType", "Builder"),
+        TypeReference.to("com.example", "DataType", "Objects"),
+        TypeReference.to("com.example", "DataType_Builder", "Partial"),
+        TypeReference.to("com.example", "DataType_Builder", "Property"),
+        TypeReference.to("com.example", "DataType_Builder", "Value"));
+  }
+
+  @Test
+  public void valueTypeSuperclassesNestedClassesAddedToVisibleList() throws CannotGenerateCodeException {
+     model.newType(
+        "package com.example;",
+        "public class SuperType {",
+        "  public interface Objects {}",
+        "}");
+     TypeElement dataType = model.newType(
+        "package com.example;",
+        "public class DataType extends SuperType {",
+        "  DataType(int i) { }",
+        "  DataType() { }",
+        "  DataType(String s) { }",
+        "  public static class Builder extends DataType_Builder {}",
+        "}");
+
+    Metadata metadata = analyser.analyse(dataType);
+
+    assertThat(metadata.getVisibleNestedTypes()).containsExactly(
+        TypeReference.to("com.example", "SuperType", "Objects"),
+        TypeReference.to("com.example", "DataType", "Builder"),
+        TypeReference.to("com.example", "DataType_Builder", "Partial"),
+        TypeReference.to("com.example", "DataType_Builder", "Property"),
+        TypeReference.to("com.example", "DataType_Builder", "Value"));
   }
 
   private static final Function<Property, String> GET_NAME = new Function<Property, String>() {


### PR DESCRIPTION
Add nested classes of xxx_Builder.Value's superclass—the user's class—to the list of types visible from xxx_Builder, to avoid aliasing them by mistake. This fixes #61.