### PR TITLE
Add ParameterizedType

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
@@ -25,6 +25,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.SimpleElementVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
 
@@ -80,6 +81,10 @@ public class ModelUtils {
     return DECLARED_TYPE_VISITOR.visit(type);
   }
 
+  public static Optional<TypeVariable> maybeVariable(TypeMirror type) {
+    return TYPE_VARIABLE_VISITOR.visit(type);
+  }
+
   /** Returns the {@link TypeElement} corresponding to {@code type}, if there is one. */
   public static Optional<TypeElement> maybeAsTypeElement(TypeMirror type) {
     Optional<DeclaredType> declaredType = maybeDeclared(type);
@@ -117,5 +122,19 @@ public class ModelUtils {
           return Optional.absent();
         }
       };
-}
 
+  private static final SimpleTypeVisitor6<Optional<TypeVariable>, ?> TYPE_VARIABLE_VISITOR =
+      new SimpleTypeVisitor6<Optional<TypeVariable>, Void>() {
+
+        @Override
+        public Optional<TypeVariable> visitTypeVariable(TypeVariable t, Void p) {
+          return Optional.of(t);
+        }
+
+        @Override
+        protected Optional<TypeVariable> defaultAction(TypeMirror e, Void p) {
+          return Optional.absent();
+        }
+      };
+
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
@@ -1,0 +1,189 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.transform;
+import static java.util.Collections.nCopies;
+
+import java.util.List;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleElementVisitor6;
+import javax.lang.model.util.SimpleTypeVisitor6;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+
+public class ParameterizedType extends ValueType implements Excerpt {
+
+  public static ParameterizedType from(TypeElement typeElement) {
+    return new ParameterisedTypeForElementVisitor().visitType(typeElement, null);
+  }
+
+  public static ParameterizedType from(DeclaredType declaredType) {
+    return new ParameterisedTypeForMirrorVisitor().visitDeclared(declaredType, null);
+  }
+
+  private final QualifiedName qualifiedName;
+  private final List<?> typeParameters;
+
+  ParameterizedType(QualifiedName qualifiedName, List<?> typeParameters) {
+    this.qualifiedName = checkNotNull(qualifiedName);
+    this.typeParameters = checkNotNull(typeParameters);
+  }
+
+  public String getSimpleName() {
+    return qualifiedName.getSimpleName();
+  }
+
+  public QualifiedName getQualifiedName() {
+    return qualifiedName;
+  }
+
+  public boolean isParameterized() {
+    return !typeParameters.isEmpty();
+  }
+
+  @Override
+  public void addTo(SourceBuilder source) {
+    source.add("%s%s", qualifiedName, typeParameters());
+  }
+
+  /**
+   * Returns a new {@link TypeParameters} of the same length as this type, filled with wildcards
+   * ("?").
+   */
+  public ParameterizedType withWildcards() {
+    if (typeParameters.isEmpty()) {
+      return this;
+    }
+    return new ParameterizedType(qualifiedName, nCopies(typeParameters.size(), "?"));
+  }
+
+  /**
+   * Returns a source excerpt suitable for constructing an instance of this type, including "new"
+   * keyword but excluding brackets.
+   *
+   * <p>In Java 7+, we can use the diamond operator. Otherwise, we write out the type parameters
+   * in full.
+   */
+  public Excerpt constructor() {
+    return new Excerpt() {
+      @Override public void addTo(SourceBuilder source) {
+        if (isParameterized() && source.getSourceLevel().supportsDiamondOperator()) {
+          source.add("new %s<>", qualifiedName);
+        } else {
+          source.add("new %s", ParameterizedType.this);
+        }
+      }
+    };
+  }
+
+  /**
+   * Returns a source excerpt suitable for declaring this type, i.e. SimpleName<...>
+   */
+  public Excerpt declaration() {
+    return new Excerpt() {
+      @Override public void addTo(SourceBuilder source) {
+        source.add("%s%s", qualifiedName.getSimpleName(), typeParameters());
+      }
+    };
+  }
+
+  /**
+   * Returns a source excerpt of the type parameters of this type, including angle brackets.
+   */
+  public Excerpt typeParameters() {
+    return new Excerpt() {
+      @Override public void addTo(SourceBuilder source) {
+        if (!typeParameters.isEmpty()) {
+          String prefix = "<";
+          for (Object typeParameter : typeParameters) {
+            source.add("%s%s", prefix, typeParameter);
+            prefix = ", ";
+          }
+          source.add(">");
+        }
+      }
+    };
+  }
+
+  /**
+   * Returns a source excerpt of a JavaDoc link to this type.
+   */
+  public Excerpt javadocLink() {
+    return new Excerpt() {
+      @Override public void addTo(SourceBuilder source) {
+        source.add("{@link %s}", getQualifiedName());
+      }
+    };
+  }
+
+  /**
+   * Returns a source excerpt of a JavaDoc link to a no-args method on this type.
+   */
+  public Excerpt javadocNoArgMethodLink(final String memberName) {
+    return new Excerpt() {
+      @Override public void addTo(SourceBuilder source) {
+        source.add("{@link %s#%s()}", getQualifiedName(), memberName);
+      }
+    };
+  }
+
+  @Override
+  public String toString() {
+    return new SourceStringBuilder(SourceLevel.JAVA_6, new TypeShortener.NeverShorten())
+        .add("%s", this)
+        .toString();
+  }
+
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    fields.add("qualifiedName", qualifiedName);
+    fields.add("typeParameters", typeParameters);
+  }
+
+  private static final class ParameterisedTypeForElementVisitor
+      extends SimpleElementVisitor6<Object, Void> implements Function<Element, Object> {
+
+    @Override
+    public Object apply(Element e) {
+      return this.visit(e, null);
+    }
+
+    @Override
+    public ParameterizedType visitType(TypeElement e, Void p) {
+      return new ParameterizedType(
+          QualifiedName.of(e),
+          ImmutableList.copyOf(transform(e.getTypeParameters(), this)));
+    }
+
+    @Override
+    protected Object defaultAction(Element e, Void p) {
+      return e;
+    }
+  }
+
+  private static final class ParameterisedTypeForMirrorVisitor
+      extends SimpleTypeVisitor6<Object, Void> implements Function<TypeMirror, Object> {
+
+    @Override
+    public Object apply(TypeMirror t) {
+      return this.visit(t);
+    }
+
+    @Override
+    public ParameterizedType visitDeclared(DeclaredType t, Void p) {
+      return new ParameterizedType(
+          QualifiedName.of((TypeElement) t.asElement()),
+          ImmutableList.copyOf(transform(t.getTypeArguments(), this)));
+    }
+
+    @Override
+    protected Object defaultAction(TypeMirror e, Void p) {
+      return e;
+    }
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -107,6 +107,14 @@ public class QualifiedName extends ValueType {
     return new QualifiedName(packageName, concat(simpleNames, ImmutableList.of(simpleName)));
   }
 
+  public ParameterizedType withParameters(String... typeParameters) {
+    return new ParameterizedType(this, ImmutableList.copyOf(typeParameters));
+  }
+
+  public ParameterizedType withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
+    return new ParameterizedType(this, ImmutableList.copyOf(typeParameters));
+  }
+
   /**
    * Returns the {@link QualifiedName} of the type enclosing this one.
    *

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
@@ -1,0 +1,203 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+
+/**
+ * Fake representation of a generic top-level class element.
+ */
+public class GenericElement implements TypeElement {
+
+  /**
+   * Builder of {@link GenericElement} instances.
+   *
+   * <p>Simple type parameters can be added with {@link #addTypeParameter(String, TypeMirror...)}.
+   * For self-referential bounds, e.g. {@code Comparable<E extends Comparable<E>>}, add the
+   * parameters first, then create the bounds with {@link #getTypeParameter(String)},
+   * {@link GenericElementParameter#asType()} and {@link #asType()}.
+   *
+   * <pre>
+   * GenericElement.Builder typeBuilder =
+   *     new GenericElement.Builder(QualifiedName.of("java.lang", "Comparable"))
+   *         .addTypeParameter("E");
+   * typeBuilder.getTypeParameter("E").addBound(typeBuilder.asType());
+   * GenericElement type = typeBuilder.build();
+   */
+  public static class Builder {
+    private final QualifiedName qualifiedName;
+    private final LinkedHashMap<String, GenericElementParameter.Builder> typeParameters =
+        new LinkedHashMap<>();
+    private AtomicReference<GenericElement> element;
+
+    public Builder(QualifiedName qualifiedName) {
+      checkArgument(qualifiedName.isTopLevel(),
+          "GenericElement currently only supports creating top-level classes");
+      this.qualifiedName = qualifiedName;
+    }
+
+    /**
+     * Adds type parameter {@code simpleName} with lower bounds {@code bounds}.
+     *
+     * @throws IllegalStateException if asType() or build() have already been called
+     * @throws IllegalStateException if a type parameter already exists with this name
+     */
+    public Builder addTypeParameter(String simpleName, TypeMirror... bounds) {
+      checkState(element == null,
+          "Cannot add a new type parameter after calling asType() or build()");
+      checkState(!typeParameters.containsKey(simpleName),
+          "Duplicate type parameter \"%s\"", simpleName);
+      GenericElementParameter.Builder typeParameter =
+          new GenericElementParameter.Builder(simpleName);
+      for (TypeMirror bound : bounds) {
+        typeParameter.addBound(bound);
+      }
+      typeParameters.put(simpleName, typeParameter);
+      return this;
+    }
+
+    /**
+     * Returns a builder for type parameter {@code simpleName}, creating one if necessary.
+     */
+    public GenericElementParameter.Builder getTypeParameter(String simpleName) {
+      GenericElementParameter.Builder typeParameter = typeParameters.get(simpleName);
+      if (typeParameter == null) {
+        checkState(element == null,
+            "Cannot add a new type parameter after calling asType() or build()");
+        typeParameter = new GenericElementParameter.Builder(simpleName);
+        typeParameters.put(simpleName, typeParameter);
+      }
+      return typeParameter;
+    }
+
+    public GenericMirror asType() {
+      if (element == null) {
+        element = new AtomicReference<>();
+      }
+      List<GenericElementParameter.TypeVariableImpl> typeArguments = new ArrayList<>();
+      for (GenericElementParameter.Builder typeParameter : typeParameters.values()) {
+        typeArguments.add(typeParameter.asType());
+      }
+      return new GenericMirror(element, typeArguments);
+    }
+
+    public GenericElement build() {
+      if (element == null) {
+        element = new AtomicReference<>();
+      }
+      checkState(element.get() == null, "Cannot call build() twice");
+      GenericElement impl = new GenericElement(qualifiedName, typeParameters.values());
+      element.set(impl);
+      return impl;
+    }
+  }
+
+  private final QualifiedName qualifiedName;
+  private final ImmutableList<GenericElementParameter> typeParameters;
+
+  GenericElement(
+      QualifiedName qualifiedName,
+      Iterable<? extends GenericElementParameter.Builder> typeParameterBuilders) {
+    this.qualifiedName = qualifiedName;
+    ImmutableList.Builder<GenericElementParameter> typeParametersBuilder = ImmutableList.builder();
+    for (GenericElementParameter.Builder typeParameterBuilder : typeParameterBuilders) {
+      typeParametersBuilder.add(typeParameterBuilder.build(this));
+    }
+    this.typeParameters = typeParametersBuilder.build();
+  }
+
+  @Override
+  public GenericMirror asType() {
+    List<TypeVariable> typeArguments = new ArrayList<>();
+    for (GenericElementParameter typeParameter : typeParameters) {
+      typeArguments.add(typeParameter.asType());
+    }
+    return new GenericMirror(new AtomicReference<>(this), typeArguments);
+  }
+
+  @Override
+  public ElementKind getKind() {
+    return ElementKind.CLASS;
+  }
+
+  @Override
+  public List<? extends AnnotationMirror> getAnnotationMirrors() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+    return null;
+  }
+
+  @Override
+  public ImmutableSet<Modifier> getModifiers() {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+    return v.visitType(this, p);
+  }
+
+  @Override
+  public List<? extends Element> getEnclosedElements() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public NestingKind getNestingKind() {
+    return NestingKind.TOP_LEVEL;
+  }
+
+  @Override
+  public Name getQualifiedName() {
+    return new NameImpl(qualifiedName.toString());
+  }
+
+  @Override
+  public Name getSimpleName() {
+    return new NameImpl(qualifiedName.getSimpleName());
+  }
+
+  @Override
+  public TypeMirror getSuperclass() {
+    return newTopLevelClass("java.lang.Object");
+  }
+
+  @Override
+  public List<? extends TypeMirror> getInterfaces() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public ImmutableList<GenericElementParameter> getTypeParameters() {
+    return typeParameters;
+  }
+
+  @Override
+  public PackageElementImpl getEnclosingElement() {
+    return new PackageElementImpl(qualifiedName.getPackage());
+  }
+
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElementParameter.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElementParameter.java
@@ -1,0 +1,199 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.NullTypeImpl.NULL;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.TypeVisitor;
+
+/**
+ * Fake implementation of a formal type parameter of a {@link GenericElement}.
+ */
+public class GenericElementParameter implements TypeParameterElement {
+
+  /**
+   * Builder of {@link GenericElementParameter} instances.
+   */
+  public static class Builder {
+    private final String simpleName;
+    private final List<TypeMirror> bounds = new ArrayList<>();
+    private final AtomicReference<GenericElementParameter> element = new AtomicReference<>();
+
+    Builder(String simpleName) {
+      this.simpleName = simpleName;
+    }
+
+    public Builder addBound(TypeMirror bound) {
+      checkState(element.get() == null,
+          "Cannot modify a %s after calling build()", Builder.class.getName());
+      bounds.add(bound);
+      return this;
+    }
+
+    public TypeVariableImpl asType() {
+      return new TypeVariableImpl(element);
+    }
+
+    GenericElementParameter build(GenericElement genericElement) {
+      GenericElementParameter impl =
+          new GenericElementParameter(genericElement, simpleName, bounds);
+      boolean notYetSet = element.compareAndSet(null, impl);
+      checkState(notYetSet, "Cannot call build() twice on a %s", Builder.class.getName());
+      return impl;
+    }
+
+  }
+
+  private final GenericElement genericElement;
+  private final String simpleName;
+  private final ImmutableList<TypeMirror> bounds;
+
+  private GenericElementParameter(
+      GenericElement genericElement, String simpleName, Iterable<? extends TypeMirror> bounds) {
+    this.genericElement = genericElement;
+    this.simpleName = simpleName;
+    this.bounds = ImmutableList.copyOf(bounds);
+  }
+
+  @Override
+  public TypeVariableImpl asType() {
+    return new TypeVariableImpl(new AtomicReference<>(this));
+  }
+
+  @Override
+  public ElementKind getKind() {
+    return ElementKind.TYPE_PARAMETER;
+  }
+
+  @Override
+  public List<? extends AnnotationMirror> getAnnotationMirrors() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+    return null;
+  }
+
+  @Override
+  public Set<Modifier> getModifiers() {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Name getSimpleName() {
+    return new NameImpl(simpleName);
+  }
+
+  @Override
+  public List<? extends Element> getEnclosedElements() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+    return v.visitTypeParameter(this, p);
+  }
+
+  @Override
+  public GenericElement getGenericElement() {
+    return genericElement;
+  }
+
+  @Override
+  public List<? extends TypeMirror> getBounds() {
+    return bounds;
+  }
+
+  @Override
+  public GenericElement getEnclosingElement() {
+    return genericElement;
+  }
+
+  @Override
+  public String toString() {
+    return simpleName;
+  }
+
+  /**
+   * Fake implementation of a type variable declared by a {@link GenericElement}.
+   */
+  public static class TypeVariableImpl implements TypeVariable {
+
+    private final AtomicReference<GenericElementParameter> element;
+
+    private TypeVariableImpl(AtomicReference<GenericElementParameter> element) {
+      this.element = element;
+    }
+
+    @Override
+    public TypeKind getKind() {
+      return TypeKind.TYPEVAR;
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+      return v.visitTypeVariable(this, p);
+    }
+
+    @Override
+    public GenericElementParameter asElement() {
+      GenericElementParameter impl = getImpl("asElement()");
+      return impl;
+    }
+
+    @Override
+    public TypeMirror getUpperBound() {
+      GenericElementParameter impl = getImpl("getUpperBound()");
+      switch (impl.bounds.size()) {
+      case 0:
+        return newTopLevelClass("java.lang.Object");
+      case 1:
+        return getOnlyElement(impl.bounds);
+      default:
+        throw new UnsupportedOperationException();
+      }
+    }
+
+    @Override
+    public TypeMirror getLowerBound() {
+      return NULL;
+    }
+
+    @Override
+    public String toString() {
+      return getImpl("toString()").simpleName;
+    }
+
+    private GenericElementParameter getImpl(String calledMethod) {
+      GenericElementParameter impl = element.get();
+      checkState(impl != null,
+          "Cannot call %s on a TypeVariable returned from a %s before it is built",
+          calledMethod,
+          GenericElementParameter.Builder.class.getName());
+      return impl;
+    }
+
+  }
+
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElementTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElementTest.java
@@ -1,0 +1,150 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeVariable;
+
+import com.google.common.base.Function;
+
+import org.inferred.freebuilder.processor.util.testing.ModelRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeVariable;
+
+public class GenericElementTest {
+
+  private static final QualifiedName FOO_BAR_NAME = QualifiedName.of("org.example", "FooBar");
+
+  @Rule public final ModelRule model = new ModelRule();
+
+  @Test
+  public void testNonGenericElement() {
+    GenericElement foobar =
+        new GenericElement.Builder(FOO_BAR_NAME).build();
+    assertThat(foobar.getSimpleName().toString()).isEqualTo("FooBar");
+    assertThat(foobar.getTypeParameters()).isEmpty();
+    assertThat(SourceStringBuilder.simple(SourceLevel.JAVA_7).add("%s", foobar).toString())
+        .isEqualTo("FooBar");
+  }
+
+  @Test
+  public void testGenericElement() {
+    GenericElement foobar = new GenericElement.Builder(FOO_BAR_NAME)
+        .addTypeParameter("T")
+        .addTypeParameter("C")
+        .build();
+    assertThat(foobar.getSimpleName().toString()).isEqualTo("FooBar");
+    assertThat(foobar.getTypeParameters()).hasSize(2);
+    assertThat(foobar.getTypeParameters().get(0).getSimpleName().toString()).isEqualTo("T");
+    assertThat(foobar.getTypeParameters().get(0).toString()).isEqualTo("T");
+    assertThat(foobar.getTypeParameters().get(1).getSimpleName().toString()).isEqualTo("C");
+    assertThat(foobar.getTypeParameters().get(1).toString()).isEqualTo("C");
+  }
+
+  @Test
+  public void testBoundedGenericElement() {
+    Function<TypeElement, Void> test = new Function<TypeElement, Void>() {
+      @Override
+      public Void apply(TypeElement foobar) {
+        assertThat(foobar.getSimpleName().toString()).isEqualTo("FooBar");
+        assertThat(foobar.getTypeParameters()).hasSize(2);
+        assertThat(foobar.getTypeParameters().get(0).getSimpleName().toString()).isEqualTo("T");
+        assertThat(foobar.getTypeParameters().get(0).toString()).isEqualTo("T");
+        assertThat(foobar.getTypeParameters().get(1).getSimpleName().toString()).isEqualTo("C");
+        assertThat(foobar.getTypeParameters().get(1).toString()).isEqualTo("C");
+        return null;
+      }
+    };
+    TypeElement realFoobar =
+        model.newType("package org.example; interface FooBar<T extends Number, C> { }");
+    GenericElement fakeFoobar = new GenericElement.Builder(FOO_BAR_NAME)
+        .addTypeParameter("T", newTopLevelClass("java.lang.Number"))
+        .addTypeParameter("C")
+        .build();
+    test.apply(realFoobar);
+    test.apply(fakeFoobar);
+  }
+
+  @Test
+  public void testGenericMirror_withTypeVariables() {
+    Function<DeclaredType, Void> test = new Function<DeclaredType, Void>() {
+      @Override public Void apply(DeclaredType foobar) {
+        assertThat(foobar.asElement().getSimpleName().toString()).isEqualTo("FooBar");
+        assertThat(foobar.getTypeArguments()).hasSize(2);
+        assertThat(SourceStringBuilder.simple(SourceLevel.JAVA_7).add("%s", foobar).toString())
+            .isEqualTo("FooBar<T, C>");
+        return null;
+      }
+    };
+    DeclaredType realFoobar = (DeclaredType)
+        model.newType("package org.example; interface FooBar<T, C> { }").asType();
+    GenericMirror fakeFoobar = new GenericElement.Builder(FOO_BAR_NAME)
+        .addTypeParameter("T")
+        .addTypeParameter("C")
+        .build()
+        .asType();
+    test.apply(realFoobar);
+    test.apply(fakeFoobar);
+  }
+
+  @Test
+  public void testGenericMirror_withBounds() {
+    Function<DeclaredType, Void> test = new Function<DeclaredType, Void>() {
+      @Override public Void apply(DeclaredType foobar) {
+        assertThat(foobar.asElement().getSimpleName().toString()).isEqualTo("FooBar");
+        assertThat(foobar.getTypeArguments()).hasSize(2);
+        assertThat(SourceStringBuilder.simple(SourceLevel.JAVA_7).add("%s", foobar).toString())
+            .isEqualTo("FooBar<T, C>");
+        return null;
+      }
+    };
+    DeclaredType realFoobar = (DeclaredType)
+        model.newType("package org.example; interface FooBar<T extends Number, C> { }").asType();
+    GenericMirror fakeFoobar = new GenericElement.Builder(FOO_BAR_NAME)
+        .addTypeParameter("T", newTopLevelClass("java.lang.Number"))
+        .addTypeParameter("C")
+        .build()
+        .asType();
+    test.apply(realFoobar);
+    test.apply(fakeFoobar);
+  }
+
+  @Test
+  public void testGenericMirror_withSelfReference() {
+    Function<DeclaredType, Void> test = new Function<DeclaredType, Void>() {
+      @Override public Void apply(DeclaredType foobar) {
+        // FooBar<E extends FooBar<E>>
+        TypeElement foobarElement = maybeAsTypeElement(foobar).get();
+        assertThat(foobarElement.getSimpleName().toString()).isEqualTo("FooBar");
+        assertThat(foobar.getTypeArguments()).hasSize(1);
+        assertThat(SourceStringBuilder.simple(SourceLevel.JAVA_7).add("%s", foobar).toString())
+            .isEqualTo("FooBar<E>");
+        // E extends FooBar<E>
+        TypeParameterElement typeParameter = foobarElement.getTypeParameters().get(0);
+        assertThat(typeParameter.getSimpleName().toString()).isEqualTo("E");
+        assertThat(typeParameter.getBounds()).hasSize(1);
+        // FooBar<E>
+        DeclaredType bound = maybeDeclared(typeParameter.getBounds().get(0)).get();
+        assertThat(bound.asElement().getSimpleName().toString()).isEqualTo("FooBar");
+        assertThat(bound.getTypeArguments()).hasSize(1);
+        // E
+        TypeVariable typeArgument = maybeVariable(bound.getTypeArguments().get(0)).get();
+        assertThat(typeArgument.asElement()).isEqualTo(typeParameter);
+        return null;
+      }
+    };
+    DeclaredType realFoobar = (DeclaredType) model
+        .newType("package org.example; interface FooBar<E extends FooBar<E>> { }").asType();
+    GenericElement.Builder fakeFoobarBuilder = new GenericElement.Builder(FOO_BAR_NAME);
+    fakeFoobarBuilder.getTypeParameter("E").addBound(fakeFoobarBuilder.asType());
+    GenericMirror fakeFoobar = fakeFoobarBuilder.build().asType();
+    test.apply(realFoobar);
+    test.apply(fakeFoobar);
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericMirror.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericMirror.java
@@ -1,0 +1,57 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVisitor;
+
+/**
+ * Fake representation of a generic top-level type.
+ */
+public class GenericMirror implements DeclaredType {
+
+  private final AtomicReference<GenericElement> element;
+  private final ImmutableList<TypeMirror> typeArguments;
+
+  GenericMirror(
+      AtomicReference<GenericElement> element, Iterable<? extends TypeMirror> typeArguments) {
+    this.element = element;
+    this.typeArguments = ImmutableList.copyOf(typeArguments);
+  }
+
+  @Override
+  public TypeKind getKind() {
+    return TypeKind.DECLARED;
+  }
+
+  @Override
+  public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+    return v.visitDeclared(this, p);
+  }
+
+  @Override
+  public GenericElement asElement() {
+    GenericElement impl = element.get();
+    checkState(impl != null,
+        "Cannot call asElement() on a GenericMirror referencing an unbuilt GenericType");
+    return impl;
+  }
+
+  @Override
+  public NoType getEnclosingType() {
+    return NoTypes.NONE;
+  }
+
+  @Override
+  public List<? extends TypeMirror> getTypeArguments() {
+    return typeArguments;
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/NullTypeImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/NullTypeImpl.java
@@ -1,0 +1,23 @@
+package org.inferred.freebuilder.processor.util;
+
+import javax.lang.model.type.NullType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeVisitor;
+
+public class NullTypeImpl implements NullType {
+
+  public static final NullType NULL = new NullTypeImpl();
+
+  private NullTypeImpl() {}
+
+  @Override
+  public TypeKind getKind() {
+    return TypeKind.NULL;
+  }
+
+  @Override
+  public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+    return v.visitNull(this, p);
+  }
+
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
@@ -1,0 +1,64 @@
+package org.inferred.freebuilder.processor.util;
+
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class ParameterizedTypeTest {
+
+  private static final QualifiedName MY_TYPE_NAME = QualifiedName.of("com.example", "MyType");
+  private static final ClassTypeImpl MY_TYPE = newTopLevelClass("com.example.MyType");
+  private static final ClassTypeImpl MY_NESTED_TYPE =
+      ClassTypeImpl.newNestedClass(MY_TYPE.asElement(), "MyNestedType");
+
+  @Test
+  public void testFromDeclaredType_simpleType() {
+    ParameterizedType type = ParameterizedType.from(MY_TYPE);
+    assertEquals(MY_TYPE_NAME, type.getQualifiedName());
+    assertFalse(type.isParameterized());
+    assertEquals("MyType", prettyPrint(type, SourceLevel.JAVA_7));
+    assertEquals("new MyType", prettyPrint(type.constructor(), SourceLevel.JAVA_6));
+    assertEquals("new MyType", prettyPrint(type.constructor(), SourceLevel.JAVA_7));
+    assertEquals("MyType", prettyPrint(type.declaration(), SourceLevel.JAVA_7));
+    assertEquals("{@link MyType}", prettyPrint(type.javadocLink(), SourceLevel.JAVA_7));
+    assertEquals("{@link MyType#foo()}",
+        prettyPrint(type.javadocNoArgMethodLink("foo"), SourceLevel.JAVA_7));
+  }
+
+  @Test
+  public void testFromDeclaredType_nestedType() {
+    ParameterizedType type = ParameterizedType.from(MY_NESTED_TYPE);
+    assertEquals(QualifiedName.of("com.example", "MyType", "MyNestedType"),
+        type.getQualifiedName());
+    assertFalse(type.isParameterized());
+    assertEquals("MyType.MyNestedType", prettyPrint(type, SourceLevel.JAVA_7));
+    assertEquals("new MyType.MyNestedType", prettyPrint(type.constructor(), SourceLevel.JAVA_6));
+    assertEquals("new MyType.MyNestedType", prettyPrint(type.constructor(), SourceLevel.JAVA_7));
+    assertEquals("MyNestedType", prettyPrint(type.declaration(), SourceLevel.JAVA_7));
+    assertEquals("{@link MyType.MyNestedType}",
+        prettyPrint(type.javadocLink(), SourceLevel.JAVA_7));
+    assertEquals("{@link MyType.MyNestedType#foo()}",
+        prettyPrint(type.javadocNoArgMethodLink("foo"), SourceLevel.JAVA_7));
+  }
+
+  @Test
+  public void testFromDeclaredType_genericType() {
+    GenericElement myType = new GenericElement.Builder(MY_TYPE_NAME).addTypeParameter("V").build();
+    ParameterizedType type = ParameterizedType.from(myType);
+    assertEquals(MY_TYPE_NAME, type.getQualifiedName());
+    assertTrue(type.isParameterized());
+    assertEquals("MyType<V>", prettyPrint(type, SourceLevel.JAVA_7));
+    assertEquals("new MyType<V>", prettyPrint(type.constructor(), SourceLevel.JAVA_6));
+    assertEquals("new MyType<>", prettyPrint(type.constructor(), SourceLevel.JAVA_7));
+    assertEquals("MyType<V>", prettyPrint(type.declaration(), SourceLevel.JAVA_7));
+    assertEquals("{@link MyType}", prettyPrint(type.javadocLink(), SourceLevel.JAVA_7));
+    assertEquals("{@link MyType#foo()}",
+        prettyPrint(type.javadocNoArgMethodLink("foo"), SourceLevel.JAVA_7));
+  }
+
+  private static String prettyPrint(Excerpt type, SourceLevel sourceLevel) {
+    return SourceStringBuilder.simple(sourceLevel).add("%s", type).toString();
+  }
+
+}


### PR DESCRIPTION
This adds generic type pretty printing to SourceBuilder. Rather than add new type hierarchy to represent all possible generic parameters (e.g. arrays, primitives, etc.), a ParameterizedType can take any arbitrary list of type parameters.