### PR TITLE
Basic Jackson integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ _Automatic generation of the Builder pattern for Java 1.6+_
   - [Nested buildable types](#nested-buildable-types)
   - [Builder construction](#builder-construction)
   - [Partials](#partials)
+  - [Jackson](#jackson)
   - [GWT](#gwt)
 - [Build tools and IDEs](#build-tools-and-ides)
   - [javac](#javac)
@@ -322,6 +323,32 @@ However, when testing a component which does not rely on the full state
 restrictions of the value type, partials can reduce the fragility of your test
 suite, allowing you to add new required fields or other constraints to an
 existing value type without breaking swathes of test code.
+
+
+### Jackson
+
+To create types compatible with the [Jackson JSON serialization
+library][Jackson], use the [@JsonProperty] annotation on your getter methods as
+normal, and use the builder property of [@JsonDeserialize] to point Jackson at
+your Builder class. For instance:
+
+```java
+// This type can be freely converted to and from JSON with Jackson
+@JsonDeserialize(builder = Address.Builder.class)
+interface Address {
+    @JsonProperty("city") String getCity();
+    @JsonProperty("state") String getState();
+
+    class Builder extends Address_Builder {}
+}
+```
+
+`@FreeBuilder` will copy the [@JsonProperty] annotations to the relevant setter
+methods on the builder.
+
+[Jackson]: http://wiki.fasterxml.com/JacksonHome
+[@JsonProperty]: http://fasterxml.github.io/jackson-annotations/javadoc/2.6/com/fasterxml/jackson/annotation/JsonProperty.html
+[@JsonDeserialize]: http://fasterxml.github.io/jackson-databind/javadoc/2.6/com/fasterxml/jackson/databind/annotation/JsonDeserialize.html
 
 
 ### GWT

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.jvnet.sorcerer</groupId>
       <artifactId>sorcerer-javac</artifactId>
       <version>0.8</version>
@@ -228,6 +233,7 @@
                 <includes>
                   <include>com.google.guava:guava</include>
                   <include>com.google.code.findbugs:jsr305</include>
+                  <include>org.apache.commons:commons-lang3</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -248,6 +254,10 @@
                 <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>org.inferred.freebuilder.shaded.com.google</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache</pattern>
+                  <shadedPattern>org.inferred.freebuilder.shaded.org.apache</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,30 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.6.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.6.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.6.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-guava</artifactId>
+      <version>2.6.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>0.24</version>

--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -28,6 +28,7 @@ import static javax.tools.Diagnostic.Kind.ERROR;
 import static javax.tools.Diagnostic.Kind.NOTE;
 import static org.inferred.freebuilder.processor.BuilderFactory.NO_ARGS_CONSTRUCTOR;
 import static org.inferred.freebuilder.processor.MethodFinder.methodsOn;
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
 import static org.inferred.freebuilder.processor.util.ModelUtils.findAnnotationMirror;
 import static org.inferred.freebuilder.processor.util.ModelUtils.findProperty;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
@@ -35,7 +36,6 @@ import static org.inferred.freebuilder.processor.util.ModelUtils.maybeType;
 
 import java.beans.Introspector;
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +71,6 @@ import org.inferred.freebuilder.processor.Metadata.StandardMethod;
 import org.inferred.freebuilder.processor.Metadata.UnderrideLevel;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
 import org.inferred.freebuilder.processor.util.IsInvalidTypeVisitor;
-import org.inferred.freebuilder.processor.util.ModelUtils;
 import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 
@@ -115,6 +114,8 @@ class Analyser {
       new OptionalPropertyFactory(),
       new BuildablePropertyFactory(),
       new DefaultPropertyFactory());
+
+  private static final String JSON_PROPERTY = "com.fasterxml.jackson.annotation.JsonProperty";
 
   private static final String BUILDER_SIMPLE_NAME_TEMPLATE = "%s_Builder";
   private static final String USER_BUILDER_NAME = "Builder";
@@ -422,7 +423,8 @@ class Analyser {
             .setAllCapsName(camelCaseToAllCaps(camelCaseName))
             .setGetterName(getterName)
             .setFullyCheckedCast(CAST_IS_FULLY_CHECKED.visit(propertyType))
-            .addAllNullableAnnotations(nullableAnnotationsOn(method));
+            .addAllNullableAnnotations(nullableAnnotationsOn(method))
+            .addAllAccessorAnnotations(accessorAnnotationsOn(method));
     if (propertyType.getKind().isPrimitive()) {
       PrimitiveType unboxedType = types.getPrimitiveType(propertyType.getKind());
       TypeMirror boxedType = types.erasure(types.boxedClass(unboxedType).asType());
@@ -470,6 +472,17 @@ class Analyser {
       }
     }
     return nullableAnnotations.build();
+  }
+
+  private ImmutableList<AnnotationMirror> accessorAnnotationsOn(ExecutableElement getterMethod) {
+    ImmutableList.Builder<AnnotationMirror> accessorAnnotations = ImmutableList.builder();
+    for (AnnotationMirror annotation : elements.getAllAnnotationMirrors(getterMethod)) {
+      Name type = asElement(annotation.getAnnotationType()).getQualifiedName();
+      if (type.contentEquals(JSON_PROPERTY)) {
+        accessorAnnotations.add(annotation);
+      }
+    }
+    return accessorAnnotations.build();
   }
 
   private PropertyCodeGenerator createCodeGenerator(

--- a/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
@@ -190,8 +190,9 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine(" *")
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code %s} is null", property.getName())
-          .addLine(" */")
-          .addLine("public %s %s(%s %s) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s(%s %s) {",
               metadata.getBuilder(),
               setterName,
               property.getType(),

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
@@ -85,6 +85,7 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
         code.addLine(" * @throws NullPointerException if {@code %s} is null", property.getName());
       }
       code.addLine(" */");
+      addAccessorAnnotations(code);
       code.add("public %s %s(", metadata.getBuilder(), setterName);
       for (TypeElement nullableAnnotation : property.getNullableAnnotations()) {
         code.add("@%s ", nullableAnnotation);

--- a/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
@@ -176,8 +176,9 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code multimap} is null or contains a")
           .addLine(" *     null key or value")
-          .addLine(" */")
-          .addLine("public %s %s%s(%s<? extends %s, ? extends %s> multimap) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s%s(%s<? extends %s, ? extends %s> multimap) {",
               metadata.getBuilder(),
               PUT_ALL_PREFIX,
               property.getCapitalizedName(),

--- a/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
@@ -151,8 +151,9 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
           .addLine(" *     null element")
-          .addLine(" */")
-          .addLine("public %s %s%s(%s<? extends %s> elements) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s%s(%s<? extends %s> elements) {",
               metadata.getBuilder(),
               ADD_ALL_PREFIX,
               property.getCapitalizedName(),

--- a/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
@@ -151,8 +151,9 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine(" * @throws NullPointerException if {@code map} is null or contains a")
           .addLine(" *     null key or value")
           .addLine(" * @throws IllegalArgumentException if any key is already present")
-          .addLine(" */")
-          .addLine("public %s %s%s(%s<? extends %s, ? extends %s> map) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s%s(%s<? extends %s, ? extends %s> map) {",
               metadata.getBuilder(),
               PUT_ALL_PREFIX,
               property.getCapitalizedName(),

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata.java
@@ -18,6 +18,7 @@ package org.inferred.freebuilder.processor;
 import static com.google.common.base.Preconditions.checkState;
 
 import javax.annotation.Nullable;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -152,6 +153,14 @@ public abstract class Metadata {
      * Returns the {@code @Nullable} annotations that have been applied to this property.
      */
     ImmutableSet<TypeElement> getNullableAnnotations();
+
+    /**
+     * Returns a list of annotations that should be applied to the accessor methods of this
+     * property; that is, the getter method, and a single setter method that will accept the result
+     * of the getter method as its argument. For a list, for example, that would be getX() and
+     * addAllX().
+     */
+    ImmutableList<AnnotationMirror> getAccessorAnnotations();
 
     /** Builder for {@link Property}. */
     class Builder extends Metadata_Property_Builder {}

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata_Property_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata_Property_Builder.java
@@ -4,14 +4,19 @@ package org.inferred.freebuilder.processor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import org.inferred.freebuilder.processor.Metadata;
@@ -27,11 +32,11 @@ abstract class Metadata_Property_Builder {
   private static final Joiner COMMA_JOINER = Joiner.on(", ").skipNulls();
 
   private enum Property {
-    ALL_CAPS_NAME("allCapsName"),
-    CAPITALIZED_NAME("capitalizedName"),
-    GETTER_NAME("getterName"),
-    NAME("name"),
     TYPE("type"),
+    NAME("name"),
+    CAPITALIZED_NAME("capitalizedName"),
+    ALL_CAPS_NAME("allCapsName"),
+    GETTER_NAME("getterName"),
     FULLY_CHECKED_CAST("fullyCheckedCast"),
     ;
 
@@ -46,40 +51,41 @@ abstract class Metadata_Property_Builder {
     }
   }
 
-  private String allCapsName;
-  @Nullable private TypeMirror boxedType = null;
-  private String capitalizedName;
-  @Nullable private PropertyCodeGenerator codeGenerator = null;
-  private String getterName;
-  private String name;
-  private LinkedHashSet<TypeElement> nullableAnnotations = new LinkedHashSet<TypeElement>();
   private TypeMirror type;
+  @Nullable private TypeMirror boxedType = null;
+  private String name;
+  private String capitalizedName;
+  private String allCapsName;
+  private String getterName;
+  @Nullable private PropertyCodeGenerator codeGenerator = null;
   private boolean fullyCheckedCast;
+  private final LinkedHashSet<TypeElement> nullableAnnotations = new LinkedHashSet<TypeElement>();
+  private final ArrayList<AnnotationMirror> accessorAnnotations = new ArrayList<AnnotationMirror>();
   private final EnumSet<Metadata_Property_Builder.Property> _unsetProperties =
       EnumSet.allOf(Metadata_Property_Builder.Property.class);
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getAllCapsName()}.
+   * Sets the value to be returned by {@link Metadata.Property#getType()}.
    *
    * @return this {@code Builder} object
-   * @throws NullPointerException if {@code allCapsName} is null
+   * @throws NullPointerException if {@code type} is null
    */
-  public Metadata.Property.Builder setAllCapsName(String allCapsName) {
-    this.allCapsName = Preconditions.checkNotNull(allCapsName);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.ALL_CAPS_NAME);
+  public Metadata.Property.Builder setType(TypeMirror type) {
+    this.type = Preconditions.checkNotNull(type);
+    _unsetProperties.remove(Metadata_Property_Builder.Property.TYPE);
     return (Metadata.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getAllCapsName()}.
+   * Returns the value that will be returned by {@link Metadata.Property#getType()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public String getAllCapsName() {
+  public TypeMirror getType() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME),
-        "allCapsName not set");
-    return allCapsName;
+        !_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE),
+        "type not set");
+    return type;
   }
 
   /**
@@ -98,6 +104,30 @@ abstract class Metadata_Property_Builder {
   @Nullable
   public TypeMirror getBoxedType() {
     return boxedType;
+  }
+
+  /**
+   * Sets the value to be returned by {@link Metadata.Property#getName()}.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code name} is null
+   */
+  public Metadata.Property.Builder setName(String name) {
+    this.name = Preconditions.checkNotNull(name);
+    _unsetProperties.remove(Metadata_Property_Builder.Property.NAME);
+    return (Metadata.Property.Builder) this;
+  }
+
+  /**
+   * Returns the value that will be returned by {@link Metadata.Property#getName()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public String getName() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(Metadata_Property_Builder.Property.NAME),
+        "name not set");
+    return name;
   }
 
   /**
@@ -125,21 +155,27 @@ abstract class Metadata_Property_Builder {
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getCodeGenerator()}.
+   * Sets the value to be returned by {@link Metadata.Property#getAllCapsName()}.
    *
    * @return this {@code Builder} object
+   * @throws NullPointerException if {@code allCapsName} is null
    */
-  public Metadata.Property.Builder setCodeGenerator(@Nullable PropertyCodeGenerator codeGenerator) {
-    this.codeGenerator = codeGenerator;
+  public Metadata.Property.Builder setAllCapsName(String allCapsName) {
+    this.allCapsName = Preconditions.checkNotNull(allCapsName);
+    _unsetProperties.remove(Metadata_Property_Builder.Property.ALL_CAPS_NAME);
     return (Metadata.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getCodeGenerator()}.
+   * Returns the value that will be returned by {@link Metadata.Property#getAllCapsName()}.
+   *
+   * @throws IllegalStateException if the field has not been set
    */
-  @Nullable
-  public PropertyCodeGenerator getCodeGenerator() {
-    return codeGenerator;
+  public String getAllCapsName() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME),
+        "allCapsName not set");
+    return allCapsName;
   }
 
   /**
@@ -167,27 +203,44 @@ abstract class Metadata_Property_Builder {
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getName()}.
+   * Sets the value to be returned by {@link Metadata.Property#getCodeGenerator()}.
    *
    * @return this {@code Builder} object
-   * @throws NullPointerException if {@code name} is null
    */
-  public Metadata.Property.Builder setName(String name) {
-    this.name = Preconditions.checkNotNull(name);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.NAME);
+  public Metadata.Property.Builder setCodeGenerator(@Nullable PropertyCodeGenerator codeGenerator) {
+    this.codeGenerator = codeGenerator;
     return (Metadata.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getName()}.
+   * Returns the value that will be returned by {@link Metadata.Property#getCodeGenerator()}.
+   */
+  @Nullable
+  public PropertyCodeGenerator getCodeGenerator() {
+    return codeGenerator;
+  }
+
+  /**
+   * Sets the value to be returned by {@link Metadata.Property#isFullyCheckedCast()}.
+   *
+   * @return this {@code Builder} object
+   */
+  public Metadata.Property.Builder setFullyCheckedCast(boolean fullyCheckedCast) {
+    this.fullyCheckedCast = fullyCheckedCast;
+    _unsetProperties.remove(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST);
+    return (Metadata.Property.Builder) this;
+  }
+
+  /**
+   * Returns the value that will be returned by {@link Metadata.Property#isFullyCheckedCast()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public String getName() {
+  public boolean isFullyCheckedCast() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.NAME),
-        "name not set");
-    return name;
+        !_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST),
+        "fullyCheckedCast not set");
+    return fullyCheckedCast;
   }
 
   /**
@@ -255,205 +308,83 @@ abstract class Metadata_Property_Builder {
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getType()}.
+   * Adds {@code element} to the list to be returned from {@link Metadata.Property#getAccessorAnnotations()}.
    *
    * @return this {@code Builder} object
-   * @throws NullPointerException if {@code type} is null
+   * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Property.Builder setType(TypeMirror type) {
-    this.type = Preconditions.checkNotNull(type);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.TYPE);
+  public Metadata.Property.Builder addAccessorAnnotations(AnnotationMirror element) {
+    this.accessorAnnotations.add(Preconditions.checkNotNull(element));
     return (Metadata.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getType()}.
-   *
-   * @throws IllegalStateException if the field has not been set
-   */
-  public TypeMirror getType() {
-    Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE),
-        "type not set");
-    return type;
-  }
-
-  /**
-   * Sets the value to be returned by {@link Metadata.Property#isFullyCheckedCast()}.
+   * Adds each element of {@code elements} to the list to be returned from
+   * {@link Metadata.Property#getAccessorAnnotations()}.
    *
    * @return this {@code Builder} object
+   * @throws NullPointerException if {@code elements} is null or contains a
+   *     null element
    */
-  public Metadata.Property.Builder setFullyCheckedCast(boolean fullyCheckedCast) {
-    this.fullyCheckedCast = fullyCheckedCast;
-    _unsetProperties.remove(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST);
+  public Metadata.Property.Builder addAccessorAnnotations(AnnotationMirror... elements) {
+    accessorAnnotations.ensureCapacity(accessorAnnotations.size() + elements.length);
+    for (AnnotationMirror element : elements) {
+      addAccessorAnnotations(element);
+    }
     return (Metadata.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#isFullyCheckedCast()}.
+   * Adds each element of {@code elements} to the list to be returned from
+   * {@link Metadata.Property#getAccessorAnnotations()}.
    *
-   * @throws IllegalStateException if the field has not been set
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code elements} is null or contains a
+   *     null element
    */
-  public boolean isFullyCheckedCast() {
-    Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST),
-        "fullyCheckedCast not set");
-    return fullyCheckedCast;
-  }
-
-  private static final class Value implements Metadata.Property {
-    private final String allCapsName;
-    @Nullable private final TypeMirror boxedType;
-    private final String capitalizedName;
-    @Nullable private final PropertyCodeGenerator codeGenerator;
-    private final String getterName;
-    private final String name;
-    private final ImmutableSet<TypeElement> nullableAnnotations;
-    private final TypeMirror type;
-    private final boolean fullyCheckedCast;
-
-    private Value(Metadata_Property_Builder builder) {
-      this.allCapsName = builder.allCapsName;
-      this.boxedType = builder.boxedType;
-      this.capitalizedName = builder.capitalizedName;
-      this.codeGenerator = builder.codeGenerator;
-      this.getterName = builder.getterName;
-      this.name = builder.name;
-      this.nullableAnnotations = ImmutableSet.copyOf(builder.nullableAnnotations);
-      this.type = builder.type;
-      this.fullyCheckedCast = builder.fullyCheckedCast;
+  public Metadata.Property.Builder addAllAccessorAnnotations(Iterable<? extends AnnotationMirror> elements) {
+    if (elements instanceof Collection) {
+      accessorAnnotations.ensureCapacity(accessorAnnotations.size() + ((Collection<?>) elements).size());
     }
-
-    @Override
-    public String getAllCapsName() {
-      return allCapsName;
+    for (AnnotationMirror element : elements) {
+      addAccessorAnnotations(element);
     }
-
-    @Override
-    @Nullable
-    public TypeMirror getBoxedType() {
-      return boxedType;
-    }
-
-    @Override
-    public String getCapitalizedName() {
-      return capitalizedName;
-    }
-
-    @Override
-    @Nullable
-    public PropertyCodeGenerator getCodeGenerator() {
-      return codeGenerator;
-    }
-
-    @Override
-    public String getGetterName() {
-      return getterName;
-    }
-
-    @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public ImmutableSet<TypeElement> getNullableAnnotations() {
-      return nullableAnnotations;
-    }
-
-    @Override
-    public TypeMirror getType() {
-      return type;
-    }
-
-    @Override
-    public boolean isFullyCheckedCast() {
-      return fullyCheckedCast;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof Metadata_Property_Builder.Value)) {
-        return false;
-      }
-      Metadata_Property_Builder.Value other = (Metadata_Property_Builder.Value) obj;
-      if (!allCapsName.equals(other.allCapsName)) {
-        return false;
-      }
-      if (boxedType != other.boxedType
-          && (boxedType == null || !boxedType.equals(other.boxedType))) {
-        return false;
-      }
-      if (!capitalizedName.equals(other.capitalizedName)) {
-        return false;
-      }
-      if (codeGenerator != other.codeGenerator
-          && (codeGenerator == null || !codeGenerator.equals(other.codeGenerator))) {
-        return false;
-      }
-      if (!getterName.equals(other.getterName)) {
-        return false;
-      }
-      if (!name.equals(other.name)) {
-        return false;
-      }
-      if (!nullableAnnotations.equals(other.nullableAnnotations)) {
-        return false;
-      }
-      if (!type.equals(other.type)) {
-        return false;
-      }
-      if (fullyCheckedCast != other.fullyCheckedCast) {
-        return false;
-      }
-      return true;
-    }
-
-    @Override
-    public int hashCode() {
-      return Arrays.hashCode(new Object[] { allCapsName, boxedType, capitalizedName, codeGenerator, getterName, name, nullableAnnotations, type, fullyCheckedCast });
-    }
-
-    @Override
-    public String toString() {
-      return "Property{"
-          + COMMA_JOINER.join(
-              "allCapsName=" + allCapsName,
-              (boxedType != null ? "boxedType=" + boxedType : null),
-              "capitalizedName=" + capitalizedName,
-              (codeGenerator != null ? "codeGenerator=" + codeGenerator : null),
-              "getterName=" + getterName,
-              "name=" + name,
-              "nullableAnnotations=" + nullableAnnotations,
-              "type=" + type,
-              "fullyCheckedCast=" + fullyCheckedCast)
-          + "}";
-    }
+    return (Metadata.Property.Builder) this;
   }
 
   /**
-   * Returns a newly-created {@link Metadata.Property} based on the contents of the {@code Builder}.
+   * Clears the list to be returned from {@link Metadata.Property#getAccessorAnnotations()}.
    *
-   * @throws IllegalStateException if any field has not been set
+   * @return this {@code Builder} object
    */
-  public Metadata.Property build() {
-    Preconditions.checkState(_unsetProperties.isEmpty(), "Not set: %s", _unsetProperties);
-    return new Metadata_Property_Builder.Value(this);
+  public Metadata.Property.Builder clearAccessorAnnotations() {
+    this.accessorAnnotations.clear();
+    return (Metadata.Property.Builder) this;
+  }
+
+  /**
+   * Returns an unmodifiable view of the list that will be returned by
+   * {@link Metadata.Property#getAccessorAnnotations()}.
+   * Changes to this builder will be reflected in the view.
+   */
+  public List<AnnotationMirror> getAccessorAnnotations() {
+    return Collections.unmodifiableList(accessorAnnotations);
   }
 
   /**
    * Sets all property values using the given {@code Metadata.Property} as a template.
    */
   public Metadata.Property.Builder mergeFrom(Metadata.Property value) {
-    setAllCapsName(value.getAllCapsName());
-    setBoxedType(value.getBoxedType());
-    setCapitalizedName(value.getCapitalizedName());
-    setCodeGenerator(value.getCodeGenerator());
-    setGetterName(value.getGetterName());
-    setName(value.getName());
-    addAllNullableAnnotations(value.getNullableAnnotations());
     setType(value.getType());
+    setBoxedType(value.getBoxedType());
+    setName(value.getName());
+    setCapitalizedName(value.getCapitalizedName());
+    setAllCapsName(value.getAllCapsName());
+    setGetterName(value.getGetterName());
+    setCodeGenerator(value.getCodeGenerator());
     setFullyCheckedCast(value.isFullyCheckedCast());
+    addAllNullableAnnotations(value.getNullableAnnotations());
+    addAllAccessorAnnotations(value.getAccessorAnnotations());
     return (Metadata.Property.Builder) this;
   }
 
@@ -465,27 +396,28 @@ abstract class Metadata_Property_Builder {
     // Upcast to access the private _unsetProperties field.
     // Otherwise, oddly, we get an access violation.
     EnumSet<Metadata_Property_Builder.Property> _templateUnset = ((Metadata_Property_Builder) template)._unsetProperties;
-    if (!_templateUnset.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)) {
-      setAllCapsName(template.getAllCapsName());
-    }
-    setBoxedType(template.getBoxedType());
-    if (!_templateUnset.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)) {
-      setCapitalizedName(template.getCapitalizedName());
-    }
-    setCodeGenerator(template.getCodeGenerator());
-    if (!_templateUnset.contains(Metadata_Property_Builder.Property.GETTER_NAME)) {
-      setGetterName(template.getGetterName());
-    }
-    if (!_templateUnset.contains(Metadata_Property_Builder.Property.NAME)) {
-      setName(template.getName());
-    }
-    addAllNullableAnnotations(((Metadata_Property_Builder) template).nullableAnnotations);
     if (!_templateUnset.contains(Metadata_Property_Builder.Property.TYPE)) {
       setType(template.getType());
     }
+    setBoxedType(template.getBoxedType());
+    if (!_templateUnset.contains(Metadata_Property_Builder.Property.NAME)) {
+      setName(template.getName());
+    }
+    if (!_templateUnset.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)) {
+      setCapitalizedName(template.getCapitalizedName());
+    }
+    if (!_templateUnset.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)) {
+      setAllCapsName(template.getAllCapsName());
+    }
+    if (!_templateUnset.contains(Metadata_Property_Builder.Property.GETTER_NAME)) {
+      setGetterName(template.getGetterName());
+    }
+    setCodeGenerator(template.getCodeGenerator());
     if (!_templateUnset.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)) {
       setFullyCheckedCast(template.isFullyCheckedCast());
     }
+    addAllNullableAnnotations(((Metadata_Property_Builder) template).nullableAnnotations);
+    addAllAccessorAnnotations(((Metadata_Property_Builder) template).accessorAnnotations);
     return (Metadata.Property.Builder) this;
   }
 
@@ -494,179 +426,29 @@ abstract class Metadata_Property_Builder {
    */
   public Metadata.Property.Builder clear() {
     Metadata_Property_Builder _template = new Metadata.Property.Builder();
-    allCapsName = _template.allCapsName;
-    boxedType = _template.boxedType;
-    capitalizedName = _template.capitalizedName;
-    codeGenerator = _template.codeGenerator;
-    getterName = _template.getterName;
-    name = _template.name;
-    nullableAnnotations.clear();
     type = _template.type;
+    boxedType = _template.boxedType;
+    name = _template.name;
+    capitalizedName = _template.capitalizedName;
+    allCapsName = _template.allCapsName;
+    getterName = _template.getterName;
+    codeGenerator = _template.codeGenerator;
     fullyCheckedCast = _template.fullyCheckedCast;
+    nullableAnnotations.clear();
+    accessorAnnotations.clear();
     _unsetProperties.clear();
     _unsetProperties.addAll(_template._unsetProperties);
     return (Metadata.Property.Builder) this;
   }
 
-  private static final class Partial implements Metadata.Property {
-    private final String allCapsName;
-    @Nullable private final TypeMirror boxedType;
-    private final String capitalizedName;
-    @Nullable private final PropertyCodeGenerator codeGenerator;
-    private final String getterName;
-    private final String name;
-    private final ImmutableSet<TypeElement> nullableAnnotations;
-    private final TypeMirror type;
-    private final boolean fullyCheckedCast;
-    private final EnumSet<Metadata_Property_Builder.Property> _unsetProperties;
-
-    Partial(Metadata_Property_Builder builder) {
-      this.allCapsName = builder.allCapsName;
-      this.boxedType = builder.boxedType;
-      this.capitalizedName = builder.capitalizedName;
-      this.codeGenerator = builder.codeGenerator;
-      this.getterName = builder.getterName;
-      this.name = builder.name;
-      this.nullableAnnotations = ImmutableSet.copyOf(builder.nullableAnnotations);
-      this.type = builder.type;
-      this.fullyCheckedCast = builder.fullyCheckedCast;
-      this._unsetProperties = builder._unsetProperties.clone();
-    }
-
-    @Override
-    public String getAllCapsName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)) {
-        throw new UnsupportedOperationException("allCapsName not set");
-      }
-      return allCapsName;
-    }
-
-    @Override
-    @Nullable
-    public TypeMirror getBoxedType() {
-      return boxedType;
-    }
-
-    @Override
-    public String getCapitalizedName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)) {
-        throw new UnsupportedOperationException("capitalizedName not set");
-      }
-      return capitalizedName;
-    }
-
-    @Override
-    @Nullable
-    public PropertyCodeGenerator getCodeGenerator() {
-      return codeGenerator;
-    }
-
-    @Override
-    public String getGetterName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)) {
-        throw new UnsupportedOperationException("getterName not set");
-      }
-      return getterName;
-    }
-
-    @Override
-    public String getName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.NAME)) {
-        throw new UnsupportedOperationException("name not set");
-      }
-      return name;
-    }
-
-    @Override
-    public ImmutableSet<TypeElement> getNullableAnnotations() {
-      return nullableAnnotations;
-    }
-
-    @Override
-    public TypeMirror getType() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)) {
-        throw new UnsupportedOperationException("type not set");
-      }
-      return type;
-    }
-
-    @Override
-    public boolean isFullyCheckedCast() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)) {
-        throw new UnsupportedOperationException("fullyCheckedCast not set");
-      }
-      return fullyCheckedCast;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof Metadata_Property_Builder.Partial)) {
-        return false;
-      }
-      Metadata_Property_Builder.Partial other = (Metadata_Property_Builder.Partial) obj;
-      if (allCapsName != other.allCapsName
-          && (allCapsName == null || !allCapsName.equals(other.allCapsName))) {
-        return false;
-      }
-      if (boxedType != other.boxedType
-          && (boxedType == null || !boxedType.equals(other.boxedType))) {
-        return false;
-      }
-      if (capitalizedName != other.capitalizedName
-          && (capitalizedName == null || !capitalizedName.equals(other.capitalizedName))) {
-        return false;
-      }
-      if (codeGenerator != other.codeGenerator
-          && (codeGenerator == null || !codeGenerator.equals(other.codeGenerator))) {
-        return false;
-      }
-      if (getterName != other.getterName
-          && (getterName == null || !getterName.equals(other.getterName))) {
-        return false;
-      }
-      if (name != other.name
-          && (name == null || !name.equals(other.name))) {
-        return false;
-      }
-      if (!nullableAnnotations.equals(other.nullableAnnotations)) {
-        return false;
-      }
-      if (type != other.type
-          && (type == null || !type.equals(other.type))) {
-        return false;
-      }
-      if (fullyCheckedCast != other.fullyCheckedCast) {
-        return false;
-      }
-      return _unsetProperties.equals(other._unsetProperties);
-    }
-
-    @Override
-    public int hashCode() {
-      return Arrays.hashCode(new Object[] { allCapsName, boxedType, capitalizedName, codeGenerator, getterName, name, nullableAnnotations, type, fullyCheckedCast, _unsetProperties });
-    }
-
-    @Override
-    public String toString() {
-      return "partial Property{"
-          + COMMA_JOINER.join(
-              (!_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)
-                  ? "allCapsName=" + allCapsName : null),
-              (boxedType != null ? "boxedType=" + boxedType : null),
-              (!_unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)
-                  ? "capitalizedName=" + capitalizedName : null),
-              (codeGenerator != null ? "codeGenerator=" + codeGenerator : null),
-              (!_unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)
-                  ? "getterName=" + getterName : null),
-              (!_unsetProperties.contains(Metadata_Property_Builder.Property.NAME)
-                  ? "name=" + name : null),
-              "nullableAnnotations=" + nullableAnnotations,
-              (!_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)
-                  ? "type=" + type : null),
-              (!_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)
-                  ? "fullyCheckedCast=" + fullyCheckedCast : null))
-          + "}";
-    }
+  /**
+   * Returns a newly-created {@link Metadata.Property} based on the contents of the {@code Builder}.
+   *
+   * @throws IllegalStateException if any field has not been set
+   */
+  public Metadata.Property build() {
+    Preconditions.checkState(_unsetProperties.isEmpty(), "Not set: %s", _unsetProperties);
+    return new Metadata_Property_Builder.Value(this);
   }
 
   /**
@@ -681,5 +463,318 @@ abstract class Metadata_Property_Builder {
   @VisibleForTesting()
   public Metadata.Property buildPartial() {
     return new Metadata_Property_Builder.Partial(this);
+  }
+
+  private static final class Value implements Metadata.Property {
+    private final TypeMirror type;
+    @Nullable private final TypeMirror boxedType;
+    private final String name;
+    private final String capitalizedName;
+    private final String allCapsName;
+    private final String getterName;
+    @Nullable private final PropertyCodeGenerator codeGenerator;
+    private final boolean fullyCheckedCast;
+    private final ImmutableSet<TypeElement> nullableAnnotations;
+    private final ImmutableList<AnnotationMirror> accessorAnnotations;
+
+    private Value(Metadata_Property_Builder builder) {
+      this.type = builder.type;
+      this.boxedType = builder.boxedType;
+      this.name = builder.name;
+      this.capitalizedName = builder.capitalizedName;
+      this.allCapsName = builder.allCapsName;
+      this.getterName = builder.getterName;
+      this.codeGenerator = builder.codeGenerator;
+      this.fullyCheckedCast = builder.fullyCheckedCast;
+      this.nullableAnnotations = ImmutableSet.copyOf(builder.nullableAnnotations);
+      this.accessorAnnotations = ImmutableList.copyOf(builder.accessorAnnotations);
+    }
+
+    @Override
+    public TypeMirror getType() {
+      return type;
+    }
+
+    @Override
+    @Nullable
+    public TypeMirror getBoxedType() {
+      return boxedType;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getCapitalizedName() {
+      return capitalizedName;
+    }
+
+    @Override
+    public String getAllCapsName() {
+      return allCapsName;
+    }
+
+    @Override
+    public String getGetterName() {
+      return getterName;
+    }
+
+    @Override
+    @Nullable
+    public PropertyCodeGenerator getCodeGenerator() {
+      return codeGenerator;
+    }
+
+    @Override
+    public boolean isFullyCheckedCast() {
+      return fullyCheckedCast;
+    }
+
+    @Override
+    public ImmutableSet<TypeElement> getNullableAnnotations() {
+      return nullableAnnotations;
+    }
+
+    @Override
+    public ImmutableList<AnnotationMirror> getAccessorAnnotations() {
+      return accessorAnnotations;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof Metadata_Property_Builder.Value)) {
+        return false;
+      }
+      Metadata_Property_Builder.Value other = (Metadata_Property_Builder.Value) obj;
+      if (!type.equals(other.type)) {
+        return false;
+      }
+      if (boxedType != other.boxedType
+          && (boxedType == null || !boxedType.equals(other.boxedType))) {
+        return false;
+      }
+      if (!name.equals(other.name)) {
+        return false;
+      }
+      if (!capitalizedName.equals(other.capitalizedName)) {
+        return false;
+      }
+      if (!allCapsName.equals(other.allCapsName)) {
+        return false;
+      }
+      if (!getterName.equals(other.getterName)) {
+        return false;
+      }
+      if (codeGenerator != other.codeGenerator
+          && (codeGenerator == null || !codeGenerator.equals(other.codeGenerator))) {
+        return false;
+      }
+      if (fullyCheckedCast != other.fullyCheckedCast) {
+        return false;
+      }
+      if (!nullableAnnotations.equals(other.nullableAnnotations)) {
+        return false;
+      }
+      if (!accessorAnnotations.equals(other.accessorAnnotations)) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(new Object[] { type, boxedType, name, capitalizedName, allCapsName, getterName, codeGenerator, fullyCheckedCast, nullableAnnotations, accessorAnnotations });
+    }
+
+    @Override
+    public String toString() {
+      return "Property{"
+          + COMMA_JOINER.join(
+              "type=" + type,
+              (boxedType != null ? "boxedType=" + boxedType : null),
+              "name=" + name,
+              "capitalizedName=" + capitalizedName,
+              "allCapsName=" + allCapsName,
+              "getterName=" + getterName,
+              (codeGenerator != null ? "codeGenerator=" + codeGenerator : null),
+              "fullyCheckedCast=" + fullyCheckedCast,
+              "nullableAnnotations=" + nullableAnnotations,
+              "accessorAnnotations=" + accessorAnnotations)
+          + "}";
+    }
+  }
+
+  private static final class Partial implements Metadata.Property {
+    private final TypeMirror type;
+    @Nullable private final TypeMirror boxedType;
+    private final String name;
+    private final String capitalizedName;
+    private final String allCapsName;
+    private final String getterName;
+    @Nullable private final PropertyCodeGenerator codeGenerator;
+    private final boolean fullyCheckedCast;
+    private final ImmutableSet<TypeElement> nullableAnnotations;
+    private final ImmutableList<AnnotationMirror> accessorAnnotations;
+    private final EnumSet<Metadata_Property_Builder.Property> _unsetProperties;
+
+    Partial(Metadata_Property_Builder builder) {
+      this.type = builder.type;
+      this.boxedType = builder.boxedType;
+      this.name = builder.name;
+      this.capitalizedName = builder.capitalizedName;
+      this.allCapsName = builder.allCapsName;
+      this.getterName = builder.getterName;
+      this.codeGenerator = builder.codeGenerator;
+      this.fullyCheckedCast = builder.fullyCheckedCast;
+      this.nullableAnnotations = ImmutableSet.copyOf(builder.nullableAnnotations);
+      this.accessorAnnotations = ImmutableList.copyOf(builder.accessorAnnotations);
+      this._unsetProperties = builder._unsetProperties.clone();
+    }
+
+    @Override
+    public TypeMirror getType() {
+      if (_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)) {
+        throw new UnsupportedOperationException("type not set");
+      }
+      return type;
+    }
+
+    @Override
+    @Nullable
+    public TypeMirror getBoxedType() {
+      return boxedType;
+    }
+
+    @Override
+    public String getName() {
+      if (_unsetProperties.contains(Metadata_Property_Builder.Property.NAME)) {
+        throw new UnsupportedOperationException("name not set");
+      }
+      return name;
+    }
+
+    @Override
+    public String getCapitalizedName() {
+      if (_unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)) {
+        throw new UnsupportedOperationException("capitalizedName not set");
+      }
+      return capitalizedName;
+    }
+
+    @Override
+    public String getAllCapsName() {
+      if (_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)) {
+        throw new UnsupportedOperationException("allCapsName not set");
+      }
+      return allCapsName;
+    }
+
+    @Override
+    public String getGetterName() {
+      if (_unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)) {
+        throw new UnsupportedOperationException("getterName not set");
+      }
+      return getterName;
+    }
+
+    @Override
+    @Nullable
+    public PropertyCodeGenerator getCodeGenerator() {
+      return codeGenerator;
+    }
+
+    @Override
+    public boolean isFullyCheckedCast() {
+      if (_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)) {
+        throw new UnsupportedOperationException("fullyCheckedCast not set");
+      }
+      return fullyCheckedCast;
+    }
+
+    @Override
+    public ImmutableSet<TypeElement> getNullableAnnotations() {
+      return nullableAnnotations;
+    }
+
+    @Override
+    public ImmutableList<AnnotationMirror> getAccessorAnnotations() {
+      return accessorAnnotations;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof Metadata_Property_Builder.Partial)) {
+        return false;
+      }
+      Metadata_Property_Builder.Partial other = (Metadata_Property_Builder.Partial) obj;
+      if (type != other.type
+          && (type == null || !type.equals(other.type))) {
+        return false;
+      }
+      if (boxedType != other.boxedType
+          && (boxedType == null || !boxedType.equals(other.boxedType))) {
+        return false;
+      }
+      if (name != other.name
+          && (name == null || !name.equals(other.name))) {
+        return false;
+      }
+      if (capitalizedName != other.capitalizedName
+          && (capitalizedName == null || !capitalizedName.equals(other.capitalizedName))) {
+        return false;
+      }
+      if (allCapsName != other.allCapsName
+          && (allCapsName == null || !allCapsName.equals(other.allCapsName))) {
+        return false;
+      }
+      if (getterName != other.getterName
+          && (getterName == null || !getterName.equals(other.getterName))) {
+        return false;
+      }
+      if (codeGenerator != other.codeGenerator
+          && (codeGenerator == null || !codeGenerator.equals(other.codeGenerator))) {
+        return false;
+      }
+      if (fullyCheckedCast != other.fullyCheckedCast) {
+        return false;
+      }
+      if (!nullableAnnotations.equals(other.nullableAnnotations)) {
+        return false;
+      }
+      if (!accessorAnnotations.equals(other.accessorAnnotations)) {
+        return false;
+      }
+      return _unsetProperties.equals(other._unsetProperties);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(new Object[] { type, boxedType, name, capitalizedName, allCapsName, getterName, codeGenerator, fullyCheckedCast, nullableAnnotations, accessorAnnotations, _unsetProperties });
+    }
+
+    @Override
+    public String toString() {
+      return "partial Property{"
+          + COMMA_JOINER.join(
+              (!_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)
+                  ? "type=" + type : null),
+              (boxedType != null ? "boxedType=" + boxedType : null),
+              (!_unsetProperties.contains(Metadata_Property_Builder.Property.NAME)
+                  ? "name=" + name : null),
+              (!_unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)
+                  ? "capitalizedName=" + capitalizedName : null),
+              (!_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)
+                  ? "allCapsName=" + allCapsName : null),
+              (!_unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)
+                  ? "getterName=" + getterName : null),
+              (codeGenerator != null ? "codeGenerator=" + codeGenerator : null),
+              (!_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)
+                  ? "fullyCheckedCast=" + fullyCheckedCast : null),
+              "nullableAnnotations=" + nullableAnnotations,
+              "accessorAnnotations=" + accessorAnnotations)
+          + "}";
+    }
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetPropertyFactory.java
@@ -140,8 +140,9 @@ public class MultisetPropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
           .addLine(" *     null element")
-          .addLine(" */")
-          .addLine("public %s %s%s(%s<? extends %s> elements) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s%s(%s<? extends %s> elements) {",
               metadata.getBuilder(),
               ADD_ALL_PREFIX,
               property.getCapitalizedName(),

--- a/src/main/java/org/inferred/freebuilder/processor/OptionalPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/OptionalPropertyFactory.java
@@ -163,8 +163,9 @@ public class OptionalPropertyFactory implements PropertyCodeGenerator.Factory {
               metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
           .addLine(" *")
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
-          .addLine(" */")
-          .addLine("public %s %s(%s<? extends %s> %s) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s(%s<? extends %s> %s) {",
               metadata.getBuilder(),
               setterName,
               Optional.class,

--- a/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
@@ -17,6 +17,7 @@ package org.inferred.freebuilder.processor;
 
 import java.util.Set;
 
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
@@ -115,6 +116,12 @@ public abstract class PropertyCodeGenerator {
 
   /** Adds a partial clear call for the property to the builder's source code. */
   public abstract void addPartialClear(SourceBuilder code);
+
+  protected void addAccessorAnnotations(SourceBuilder code) {
+    for (AnnotationMirror annotation : property.getAccessorAnnotations()) {
+      code.addLine("%s", annotation);
+    }
+  }
 
   public static final Predicate<PropertyCodeGenerator> IS_TEMPLATE_REQUIRED_IN_CLEAR =
       new Predicate<PropertyCodeGenerator>() {

--- a/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
@@ -177,8 +177,9 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code multimap} is null or contains a")
           .addLine(" *     null key or value")
-          .addLine(" */")
-          .addLine("public %s %s%s(%s<? extends %s, ? extends %s> multimap) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s%s(%s<? extends %s, ? extends %s> multimap) {",
               metadata.getBuilder(),
               PUT_ALL_PREFIX,
               property.getCapitalizedName(),

--- a/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
@@ -154,8 +154,9 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
           .addLine(" *     null element")
-          .addLine(" */")
-          .addLine("public %s %s%s(%s<? extends %s> elements) {",
+          .addLine(" */");
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s%s(%s<? extends %s> elements) {",
               metadata.getBuilder(),
               ADD_ALL_PREFIX,
               property.getCapitalizedName(),

--- a/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
@@ -1,0 +1,114 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.apache.commons.lang3.StringEscapeUtils.escapeJava;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
+
+import java.util.List;
+import java.util.Map.Entry;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.util.SimpleAnnotationValueVisitor6;
+
+/**
+ * Static methods for annotation-related source-code generation.
+ */
+public class AnnotationSource {
+
+  /**
+   * Adds a source-code representation of {@code annotation} to {@code}.
+   */
+  public static void addSource(SourceBuilder code, AnnotationMirror annotation) {
+    new ValueSourceAdder(code).visitAnnotation(annotation, null);
+  }
+
+  /**
+   * Returns true if {@code annotation} has a single element named "value", letting us drop the
+   * 'value=' prefix in the source code.
+   */
+  private static boolean hasSingleValueWithDefaultKey(AnnotationMirror annotation) {
+    if (annotation.getElementValues().size() != 1) {
+      return false;
+    }
+    ExecutableElement key = getOnlyElement(annotation.getElementValues().keySet());
+    return key.getSimpleName().contentEquals("value");
+  }
+
+  private static class ValueSourceAdder
+      extends SimpleAnnotationValueVisitor6<Void, AnnotationValue> {
+
+    private final SourceBuilder code;
+
+    ValueSourceAdder(SourceBuilder code) {
+      this.code = code;
+    }
+
+    @Override
+    public Void visitAnnotation(AnnotationMirror annotation, AnnotationValue unused) {
+      // By explicitly adding annotations rather than relying on AnnotationMirror.toString(),
+      // we can import the types and make the code (hopefully) more readable.
+      code.add("@%s", QualifiedName.of(maybeAsTypeElement(annotation.getAnnotationType()).get()));
+      if (annotation.getElementValues().isEmpty()) {
+        return null;
+      }
+      code.add("(");
+      if (hasSingleValueWithDefaultKey(annotation)) {
+        AnnotationValue value = getOnlyElement(annotation.getElementValues().values());
+        visit(value, value);
+      } else {
+        String separator = "";
+        for (Entry<? extends ExecutableElement, ? extends AnnotationValue> entry
+            : annotation.getElementValues().entrySet()) {
+          code.add("%s%s = ", separator, entry.getKey().getSimpleName());
+          visit(entry.getValue(), entry.getValue());
+          separator = ", ";
+        }
+      }
+      code.add(")");
+      return null;
+    }
+
+    @Override
+    public Void visitArray(List<? extends AnnotationValue> vals, AnnotationValue unused) {
+      // Single-element arrays can omit the enclosing braces
+      if (vals.size() == 1) {
+        AnnotationValue value = getOnlyElement(vals);
+        visit(value, value);
+      } else {
+        code.add("{");
+        String separator = "";
+        for (AnnotationValue value : vals) {
+          code.add(separator);
+          visit(value, value);
+          separator = ", ";
+        }
+        code.add("}");
+      }
+      return null;
+    }
+
+    @Override
+    public Void visitString(String s, AnnotationValue p) {
+      // Some versions of Eclipse contain a bug where strings are not correctly escaped by
+      // AnnotationValue.toString(), so we special-case strings to ensure it's done correctly.
+      code.add("\"%s\"", escapeJava(s));
+      return null;
+    }
+
+    @Override
+    protected Void defaultAction(Object obj, AnnotationValue value) {
+      code.add("%s", value.toString());
+      return null;
+    }
+
+    @Override
+    public Void visitUnknown(AnnotationValue value, AnnotationValue unused) {
+      code.add("%s", value.toString());
+      return null;
+    }
+  }
+
+  private AnnotationSource() { }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
@@ -2,7 +2,7 @@ package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.apache.commons.lang3.StringEscapeUtils.escapeJava;
-import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
 
 import java.util.List;
 import java.util.Map.Entry;
@@ -49,7 +49,7 @@ public class AnnotationSource {
     public Void visitAnnotation(AnnotationMirror annotation, AnnotationValue unused) {
       // By explicitly adding annotations rather than relying on AnnotationMirror.toString(),
       // we can import the types and make the code (hopefully) more readable.
-      code.add("@%s", QualifiedName.of(maybeAsTypeElement(annotation.getAnnotationType()).get()));
+      code.add("@%s", QualifiedName.of(asElement(annotation.getAnnotationType())));
       if (annotation.getElementValues().isEmpty()) {
         return null;
       }

--- a/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.collect.Iterables.getOnlyElement;

--- a/src/main/java/org/inferred/freebuilder/processor/util/Excerpt.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Excerpt.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
@@ -95,6 +95,11 @@ public class ModelUtils {
     }
   }
 
+  /** Returns the {@link TypeElement} corresponding to {@code type}. */
+  public static TypeElement asElement(DeclaredType type) {
+    return maybeType(type.asElement()).get();
+  }
+
   private static final SimpleElementVisitor6<Optional<TypeElement>, ?> TYPE_ELEMENT_VISITOR =
       new SimpleElementVisitor6<Optional<TypeElement>, Void>() {
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/org/inferred/freebuilder/processor/util/Shading.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Shading.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilders.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilders.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import com.google.common.base.Strings;

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceLevel.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import javax.lang.model.SourceVersion;

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
@@ -16,7 +16,9 @@
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.inferred.freebuilder.processor.util.AnnotationSource.addSource;
 
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.PackageElement;
@@ -102,6 +104,10 @@ public final class SourceStringBuilder implements SourceBuilder {
       return shortener.shorten(mirror);
     } else if (arg instanceof QualifiedName) {
       return shortener.shorten((QualifiedName) arg);
+    } else if (arg instanceof AnnotationMirror) {
+      SourceStringBuilder excerptBuilder = new SourceStringBuilder(sourceLevel, shortener);
+      addSource(excerptBuilder, (AnnotationMirror) arg);
+      return excerptBuilder.toString();
     } else {
       return arg;
     }

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -21,17 +21,19 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.BuilderFactory.BUILDER_METHOD;
 import static org.inferred.freebuilder.processor.BuilderFactory.NEW_BUILDER_METHOD;
 import static org.inferred.freebuilder.processor.BuilderFactory.NO_ARGS_CONSTRUCTOR;
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Map;
-
-import javax.annotation.Generated;
-import javax.annotation.Nullable;
-import javax.lang.model.element.TypeElement;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
 import org.inferred.freebuilder.processor.Metadata.Property;
@@ -47,11 +49,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+import javax.annotation.Generated;
+import javax.annotation.Nullable;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
 
 /** Unit tests for {@link Analyser}. */
 @RunWith(JUnit4.class)
@@ -1371,6 +1374,25 @@ public class AnalyserTest {
         QualifiedName.of("com.example", "DataType_Builder", "Partial"),
         QualifiedName.of("com.example", "DataType_Builder", "Property"),
         QualifiedName.of("com.example", "DataType_Builder", "Value"));
+  }
+
+  @Test
+  public void jacksonAnnotationAddedToAccessorAnnotations() throws CannotGenerateCodeException {
+     TypeElement dataType = model.newType(
+        "package com.example;",
+        "public interface DataType {",
+        "  @" + JsonProperty.class.getName() + "(\"foobar\")",
+        "  int getFooBar();",
+        "  class Builder extends DataType_Builder {}",
+        "}");
+
+    Metadata metadata = analyser.analyse(dataType);
+
+    Property property = getOnlyElement(metadata.getProperties());
+    assertThat(property.getAccessorAnnotations()).hasSize(1);
+    AnnotationMirror accessorAnnotation = getOnlyElement(property.getAccessorAnnotations());
+    assertThat(asElement(accessorAnnotation.getAnnotationType()).getSimpleName().toString())
+        .isEqualTo("JsonProperty");
   }
 
   private static final Function<Property, String> GET_NAME = new Function<Property, String>() {

--- a/src/test/java/org/inferred/freebuilder/processor/BuildablePropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildablePropertyFactoryTest.java
@@ -15,10 +15,10 @@
  */
 package org.inferred.freebuilder.processor;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.tools.JavaFileObject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
@@ -30,7 +30,10 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.tools.JavaFileObject;
 
 @RunWith(JUnit4.class)
 public class BuildablePropertyFactoryTest {
@@ -863,6 +866,55 @@ public class BuildablePropertyFactoryTest {
             .addLine("        .setName(\"thingy\"))")
             .addLine("    .build();")
             .addLine("assertEquals(\"thingy\", value.getTemplate().getName());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testJacksonInteroperability() {
+    // See also https://github.com/google/FreeBuilder/issues/68
+    behaviorTester
+        .with(new Processor())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("import " + JsonProperty.class.getName() + ";")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("@%s(builder = DataType.Builder.class)", JsonDeserialize.class)
+            .addLine("public interface DataType {")
+            .addLine("  @%s", FreeBuilder.class)
+            .addLine("  @%s(builder = Item.Builder.class)", JsonDeserialize.class)
+            .addLine("  interface Item {")
+            .addLine("    @JsonProperty(\"name\") String getName();")
+            .addLine("    @JsonProperty(\"price\") int getPrice();")
+            .addLine("")
+            .addLine("    class Builder extends DataType_Item_Builder {}")
+            .addLine("  }")
+            .addLine("")
+            .addLine("  @JsonProperty(\"one\") Item getItem1();")
+            .addLine("  @JsonProperty(\"two\") Item getItem2();")
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {}")
+            .addLine("}")
+            .build())
+        .with(new TestBuilder()
+            .addImport("com.example.DataType")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setItem1(new DataType.Item.Builder()")
+            .addLine("        .setName(\"Foo\")")
+            .addLine("        .setPrice(1)")
+            .addLine("        .build())")
+            .addLine("    .setItem2(new DataType.Item.Builder()")
+            .addLine("        .setName(\"Bar\")")
+            .addLine("        .setPrice(2)")
+            .addLine("        .build())")
+            .addLine("    .build();")
+            .addLine("%1$s mapper = new %1$s();", ObjectMapper.class)
+            .addLine("String json = mapper.writeValueAsString(value);")
+            .addLine("DataType clone = mapper.readValue(json, DataType.class);")
+            .addLine("assertEquals(\"Foo\", clone.getItem1().getName());")
+            .addLine("assertEquals(1, clone.getItem1().getPrice());")
+            .addLine("assertEquals(\"Bar\", clone.getItem2().getName());")
+            .addLine("assertEquals(2, clone.getItem2().getPrice());")
             .build())
         .runTest();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeElementImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeElementImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor;
 
 import javax.lang.model.element.Element;

--- a/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
@@ -15,9 +15,19 @@
  */
 package org.inferred.freebuilder.processor;
 
-import java.util.Iterator;
-
-import javax.tools.JavaFileObject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.testing.EqualsTester;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
@@ -29,15 +39,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.google.common.testing.EqualsTester;
+import java.util.Iterator;
+
+import javax.tools.JavaFileObject;
 
 @RunWith(JUnit4.class)
 public class ListMultimapPropertyFactoryTest {
@@ -860,6 +864,40 @@ public class ListMultimapPropertyFactoryTest {
             .addLine("            .putItems(\"one\", \"A\")")
             .addLine("            .build())")
             .addLine("    .testEquals();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testJacksonInteroperability() {
+    // See also https://github.com/google/FreeBuilder/issues/68
+    behaviorTester
+        .with(new Processor())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("import " + JsonProperty.class.getName() + ";")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("@%s(builder = DataType.Builder.class)", JsonDeserialize.class)
+            .addLine("public interface DataType {")
+            .addLine("  @JsonProperty(\"stuff\") %s<String, String> getItems();", Multimap.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {}")
+            .addLine("}")
+            .build())
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .putItems(\"two\", \"B\")")
+            .addLine("    .build();")
+            .addLine("%1$s mapper = new %1$s()", ObjectMapper.class)
+            .addLine("    .registerModule(new %s());", GuavaModule.class)
+            .addLine("String json = mapper.writeValueAsString(value);")
+            .addLine("DataType clone = mapper.readValue(json, DataType.class);")
+            .addLine("assertThat(clone.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"B\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
             .build())
         .runTest();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/ListPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListPropertyFactoryTest.java
@@ -15,10 +15,11 @@
  */
 package org.inferred.freebuilder.processor;
 
-import java.util.Iterator;
-import java.util.List;
-
-import javax.tools.JavaFileObject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
@@ -30,8 +31,10 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.testing.EqualsTester;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.tools.JavaFileObject;
 
 /** Behavioral tests for {@code List<?>} properties. */
 @RunWith(JUnit4.class)
@@ -403,6 +406,36 @@ public class ListPropertyFactoryTest {
             .addLine("    .addAllItems(%s.of(3, 4))", ImmutableList.class)
             .addLine("    .build();")
             .addLine("assertThat(value.getItems()).isEmpty();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testJacksonInteroperability() {
+    // See also https://github.com/google/FreeBuilder/issues/68
+    behaviorTester
+        .with(new Processor())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("import " + JsonProperty.class.getName() + ";")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("@%s(builder = DataType.Builder.class)", JsonDeserialize.class)
+            .addLine("public interface DataType {")
+            .addLine("  @JsonProperty(\"stuff\") %s<%s> getItems();", List.class, String.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {}")
+            .addLine("}")
+            .build())
+        .with(new TestBuilder()
+            .addImport("com.example.DataType")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addItems(\"one\")")
+            .addLine("    .addItems(\"two\")")
+            .addLine("    .build();")
+            .addLine("%1$s mapper = new %1$s();", ObjectMapper.class)
+            .addLine("String json = mapper.writeValueAsString(value);")
+            .addLine("DataType clone = mapper.readValue(json, DataType.class);")
+            .addLine("assertThat(clone.getItems()).containsExactly(\"one\", \"two\").inOrder();")
             .build())
         .runTest();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/OptionalPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/OptionalPropertyFactoryTest.java
@@ -15,7 +15,14 @@
  */
 package org.inferred.freebuilder.processor;
 
-import javax.tools.JavaFileObject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
@@ -27,10 +34,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.testing.EqualsTester;
+import javax.tools.JavaFileObject;
 
 /** Behavioral tests for {@code Optional<?>} properties. */
 @RunWith(JUnit4.class)
@@ -863,6 +867,36 @@ public class OptionalPropertyFactoryTest {
             .addLine("    .setItems(%s.of(1, 2, 3, 4))", ImmutableList.class)
             .addLine("    .build();")
             .addLine("assertThat(value.getItems().get()).containsExactly(1, 2, 3, 4).inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testJacksonInteroperability() {
+    // See also https://github.com/google/FreeBuilder/issues/68
+    behaviorTester
+        .with(new Processor())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("import " + JsonProperty.class.getName() + ";")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("@%s(builder = DataType.Builder.class)", JsonDeserialize.class)
+            .addLine("public interface DataType {")
+            .addLine("  @JsonProperty(\"stuff\") %s<%s> getItem();", Optional.class, String.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {}")
+            .addLine("}")
+            .build())
+        .with(new TestBuilder()
+            .addImport("com.example.DataType")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setItem(\"item\")")
+            .addLine("    .build();")
+            .addLine("%1$s mapper = new %1$s()", ObjectMapper.class)
+            .addLine("    .registerModule(new %s());", GuavaModule.class)
+            .addLine("String json = mapper.writeValueAsString(value);")
+            .addLine("DataType clone = mapper.readValue(json, DataType.class);")
+            .addLine("assertEquals(%s.of(\"item\"), clone.getItem());", Optional.class)
             .build())
         .runTest();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElementParameter.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElementParameter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkState;

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElementTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElementTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericMirror.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericMirror.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkState;

--- a/src/test/java/org/inferred/freebuilder/processor/util/NullTypeImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/NullTypeImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import javax.lang.model.type.NullType;

--- a/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;

--- a/src/test/java/org/inferred/freebuilder/processor/util/Partial.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/Partial.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/src/test/java/org/inferred/freebuilder/processor/util/SourceLevelTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/SourceLevelTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/inferred/freebuilder/processor/util/TypeVariableImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/TypeVariableImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util;
 
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/CompilationException.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/CompilationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util.testing;
 
 import java.util.List;

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/Diagnostics.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/Diagnostics.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.inferred.freebuilder.processor.util.testing;
 
 import java.io.File;


### PR DESCRIPTION
Propagate [@JsonProperty] annotations through to Builder setter methods, giving basic Jackson integration with low impact.

This fixes #68.

[@JsonProperty]: http://fasterxml.github.io/jackson-annotations/javadoc/2.6/com/fasterxml/jackson/annotation/JsonProperty.html
