### PR TITLE
Enable testing with JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: java
 script: mvn integration-test
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,17 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18.1</version>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExcludes>org.jvnet.sorcerer:sorcerer-javac</classpathDependencyExcludes>
+          </classpathDependencyExcludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <dependencies>

--- a/src/it/vanilla/src/main/java/org/inferred/freebuilder/DefaultedPropertiesType.java
+++ b/src/it/vanilla/src/main/java/org/inferred/freebuilder/DefaultedPropertiesType.java
@@ -1,0 +1,14 @@
+package org.inferred.freebuilder;
+
+@FreeBuilder
+public interface DefaultedPropertiesType {
+  String getFirstName();
+  String getSurname();
+
+  class Builder extends DefaultedPropertiesType_Builder {
+    public Builder() {
+      setFirstName("Joe");
+      setSurname("Bloggs");
+    }
+  }
+}

--- a/src/it/vanilla/src/main/java/org/inferred/freebuilder/RequiredPropertiesType.java
+++ b/src/it/vanilla/src/main/java/org/inferred/freebuilder/RequiredPropertiesType.java
@@ -1,0 +1,9 @@
+package org.inferred.freebuilder;
+
+@FreeBuilder
+public interface RequiredPropertiesType {
+  String getFirstName();
+  String getSurname();
+
+  class Builder extends RequiredPropertiesType_Builder {}
+}

--- a/src/it/vanilla/src/test/java/org/inferred/freebuilder/DefaultsOptimizationTest.java
+++ b/src/it/vanilla/src/test/java/org/inferred/freebuilder/DefaultsOptimizationTest.java
@@ -1,0 +1,22 @@
+package org.inferred.freebuilder;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DefaultsOptimizationTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testNoDefaultsNoOptimisation() throws NoSuchFieldException, SecurityException {
+    RequiredPropertiesType.Builder.class.getSuperclass().getDeclaredField("_unsetProperties");
+  }
+
+  @Test
+  public void testDefaultsOptimisation() throws NoSuchFieldException, SecurityException {
+    thrown.expect(NoSuchFieldException.class);
+    DefaultedPropertiesType.Builder.class.getSuperclass().getDeclaredField("_unsetProperties");
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeElementImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeElementImpl.java
@@ -42,10 +42,10 @@ import com.google.common.collect.ImmutableList;
 abstract class GenericTypeElementImpl extends ValueType
     implements javax.lang.model.element.TypeElement {
 
-  static GenericTypeElementImpl newTopLevelGenericType(String qualifiedName) {
+  public static GenericTypeElementImpl newTopLevelGenericType(String qualifiedName) {
     String pkg = qualifiedName.substring(0, qualifiedName.lastIndexOf('.'));
     String simpleName = qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
-    PackageElement enclosingElement = new PackageElementImpl(pkg);
+    PackageElement enclosingElement = PackageElementImpl.create(pkg);
     return Partial.of(GenericTypeElementImpl.class, enclosingElement, NoTypes.NONE, simpleName);
   }
 
@@ -53,8 +53,7 @@ abstract class GenericTypeElementImpl extends ValueType
   private final TypeMirror enclosingType;
   private final String simpleName;
 
-  public GenericTypeElementImpl(
-      Element enclosingElement, TypeMirror enclosingType, String simpleName) {
+  GenericTypeElementImpl(Element enclosingElement, TypeMirror enclosingType, String simpleName) {
     this.enclosingElement = enclosingElement;
     this.enclosingType = enclosingType;
     this.simpleName = simpleName;
@@ -68,7 +67,7 @@ abstract class GenericTypeElementImpl extends ValueType
   }
 
   public GenericTypeMirrorImpl newMirror(TypeMirror... typeArguments) {
-    return new GenericTypeMirrorImpl(ImmutableList.copyOf(typeArguments));
+    return Partial.of(GenericTypeMirrorImpl.class, this, ImmutableList.copyOf(typeArguments));
   }
 
   @Override
@@ -102,7 +101,7 @@ abstract class GenericTypeElementImpl extends ValueType
     return enclosingElement;
   }
 
-  class GenericTypeMirrorImpl extends ValueType implements DeclaredType {
+  abstract class GenericTypeMirrorImpl extends ValueType implements DeclaredType {
     private final ImmutableList<TypeMirror> typeArguments;
 
     GenericTypeMirrorImpl(ImmutableList<TypeMirror> typeArguments) {

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -23,8 +23,6 @@ import com.google.common.testing.EqualsTester;
 import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.server.rpc.RPC;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
@@ -611,46 +609,6 @@ public class ProcessorTest {
             .addLine("com.example.DataType.builder()")
             .addLine("    .setPropertyA(11)")
             .addLine("    .isPropertyB();")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void testNoDefaultsOptimization() {
-    behaviorTester
-        .with(new Processor())
-        .with(TWO_PROPERTY_FREE_BUILDER_TYPE)
-        .with(new TestBuilder()
-            .addLine("com.example.DataType.Builder.class.getSuperclass()")
-            .addLine("    .getDeclaredField(\"_unsetProperties\");")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void testDefaultsOptimization() {
-    thrown.expect(new BaseMatcher<Throwable>() {
-
-      @Override
-      public boolean matches(Object obj) {
-        if (!(obj instanceof Throwable)) {
-          return false;
-        }
-        Throwable cause = ((Throwable) obj).getCause();
-        return ((cause instanceof NoSuchFieldException)
-            && cause.getMessage().equals("_unsetProperties"));
-      }
-
-      @Override
-      public void describeTo(Description desc) {
-        desc.appendText("caused by: java.lang.NoSuchFieldException: _unsetProperties");
-      }});
-    behaviorTester
-        .with(new Processor())
-        .with(TWO_DEFAULTS_FREE_BUILDER_TYPE)
-        .with(new TestBuilder()
-            .addLine("com.example.DataType.Builder.class.getSuperclass()")
-            .addLine("    .getDeclaredField(\"_unsetProperties\");")
             .build())
         .runTest();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ClassTypeImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ClassTypeImpl.java
@@ -15,15 +15,11 @@
  */
 package org.inferred.freebuilder.processor.util;
 
-import java.lang.annotation.Annotation;
 import java.util.List;
-import java.util.Set;
 
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ElementVisitor;
-import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.PackageElement;
@@ -39,7 +35,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * Fake implementation of {@link DeclaredType} for unit tests.
  */
-public class ClassTypeImpl implements DeclaredType {
+public abstract class ClassTypeImpl implements DeclaredType {
 
   private final Element enclosingElement;
   private final TypeMirror enclosingType;
@@ -48,19 +44,19 @@ public class ClassTypeImpl implements DeclaredType {
   public static ClassTypeImpl newTopLevelClass(String qualifiedName) {
     String pkg = qualifiedName.substring(0, qualifiedName.lastIndexOf('.'));
     String simpleName = qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
-    PackageElement enclosingElement = new PackageElementImpl(pkg);
-    return new ClassTypeImpl(enclosingElement, NoTypes.NONE, simpleName);
+    PackageElement enclosingElement = PackageElementImpl.create(pkg);
+    return Partial.of(ClassTypeImpl.class, enclosingElement, NoTypes.NONE, simpleName);
   }
 
   public static ClassTypeImpl newNestedClass(TypeElement enclosingType, String simpleName) {
-    return new ClassTypeImpl(enclosingType, NoTypes.NONE, simpleName);
+    return Partial.of(ClassTypeImpl.class, enclosingType, NoTypes.NONE, simpleName);
   }
 
   public static ClassTypeImpl newInnerClass(DeclaredType enclosingType, String simpleName) {
-    return new ClassTypeImpl(enclosingType.asElement(), enclosingType, simpleName);
+    return Partial.of(ClassTypeImpl.class, enclosingType.asElement(), enclosingType, simpleName);
   }
 
-  private ClassTypeImpl(Element enclosingElement, TypeMirror enclosingType, String simpleName) {
+  ClassTypeImpl(Element enclosingElement, TypeMirror enclosingType, String simpleName) {
     this.enclosingElement = enclosingElement;
     this.enclosingType = enclosingType;
     this.simpleName = simpleName;
@@ -78,7 +74,7 @@ public class ClassTypeImpl implements DeclaredType {
 
   @Override
   public ClassElementImpl asElement() {
-    return new ClassElementImpl();
+    return Partial.of(ClassElementImpl.class, this);
   }
 
   @Override
@@ -115,7 +111,7 @@ public class ClassTypeImpl implements DeclaredType {
   /**
    * Fake implementation of {@link TypeElement} for unit tests.
    */
-  public class ClassElementImpl implements TypeElement {
+  public abstract class ClassElementImpl implements TypeElement {
 
     @Override
     public ClassTypeImpl asType() {
@@ -128,28 +124,8 @@ public class ClassTypeImpl implements DeclaredType {
     }
 
     @Override
-    public List<? extends AnnotationMirror> getAnnotationMirrors() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Set<Modifier> getModifiers() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public <R, P> R accept(ElementVisitor<R, P> v, P p) {
       return v.visitType(this, p);
-    }
-
-    @Override
-    public List<? extends Element> getEnclosedElements() {
-      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -171,11 +147,6 @@ public class ClassTypeImpl implements DeclaredType {
     @Override
     public TypeMirror getSuperclass() {
       return NoTypes.NONE;
-    }
-
-    @Override
-    public List<? extends TypeMirror> getInterfaces() {
-      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
@@ -42,7 +42,7 @@ import javax.lang.model.type.TypeVariable;
 /**
  * Fake representation of a generic top-level class element.
  */
-public class GenericElement implements TypeElement {
+public abstract class GenericElement implements TypeElement {
 
   /**
    * Builder of {@link GenericElement} instances.
@@ -113,7 +113,7 @@ public class GenericElement implements TypeElement {
       for (GenericElementParameter.Builder typeParameter : typeParameters.values()) {
         typeArguments.add(typeParameter.asType());
       }
-      return new GenericMirror(element, typeArguments);
+      return GenericMirror.create(element, typeArguments);
     }
 
     public GenericElement build() {
@@ -121,7 +121,8 @@ public class GenericElement implements TypeElement {
         element = new AtomicReference<>();
       }
       checkState(element.get() == null, "Cannot call build() twice");
-      GenericElement impl = new GenericElement(qualifiedName, typeParameters.values());
+      GenericElement impl =
+          Partial.of(GenericElement.class, qualifiedName, typeParameters.values());
       element.set(impl);
       return impl;
     }
@@ -147,7 +148,7 @@ public class GenericElement implements TypeElement {
     for (GenericElementParameter typeParameter : typeParameters) {
       typeArguments.add(typeParameter.asType());
     }
-    return new GenericMirror(new AtomicReference<>(this), typeArguments);
+    return GenericMirror.create(new AtomicReference<>(this), typeArguments);
   }
 
   @Override
@@ -212,7 +213,7 @@ public class GenericElement implements TypeElement {
 
   @Override
   public PackageElementImpl getEnclosingElement() {
-    return new PackageElementImpl(qualifiedName.getPackage());
+    return PackageElementImpl.create(qualifiedName.getPackage());
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElementParameter.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElementParameter.java
@@ -44,7 +44,7 @@ import javax.lang.model.type.TypeVisitor;
 /**
  * Fake implementation of a formal type parameter of a {@link GenericElement}.
  */
-public class GenericElementParameter implements TypeParameterElement {
+public abstract class GenericElementParameter implements TypeParameterElement {
 
   /**
    * Builder of {@link GenericElementParameter} instances.
@@ -66,12 +66,12 @@ public class GenericElementParameter implements TypeParameterElement {
     }
 
     public TypeVariableImpl asType() {
-      return new TypeVariableImpl(element);
+      return Partial.of(TypeVariableImpl.class, element);
     }
 
     GenericElementParameter build(GenericElement genericElement) {
       GenericElementParameter impl =
-          new GenericElementParameter(genericElement, simpleName, bounds);
+          Partial.of(GenericElementParameter.class, genericElement, simpleName, bounds);
       boolean notYetSet = element.compareAndSet(null, impl);
       checkState(notYetSet, "Cannot call build() twice on a %s", Builder.class.getName());
       return impl;
@@ -83,7 +83,7 @@ public class GenericElementParameter implements TypeParameterElement {
   private final String simpleName;
   private final ImmutableList<TypeMirror> bounds;
 
-  private GenericElementParameter(
+  GenericElementParameter(
       GenericElement genericElement, String simpleName, Iterable<? extends TypeMirror> bounds) {
     this.genericElement = genericElement;
     this.simpleName = simpleName;
@@ -92,7 +92,7 @@ public class GenericElementParameter implements TypeParameterElement {
 
   @Override
   public TypeVariableImpl asType() {
-    return new TypeVariableImpl(new AtomicReference<>(this));
+    return Partial.of(TypeVariableImpl.class, new AtomicReference<>(this));
   }
 
   @Override
@@ -153,11 +153,11 @@ public class GenericElementParameter implements TypeParameterElement {
   /**
    * Fake implementation of a type variable declared by a {@link GenericElement}.
    */
-  public static class TypeVariableImpl implements TypeVariable {
+  public abstract static class TypeVariableImpl implements TypeVariable {
 
     private final AtomicReference<GenericElementParameter> element;
 
-    private TypeVariableImpl(AtomicReference<GenericElementParameter> element) {
+    TypeVariableImpl(AtomicReference<GenericElementParameter> element) {
       this.element = element;
     }
 

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericMirror.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericMirror.java
@@ -31,7 +31,12 @@ import javax.lang.model.type.TypeVisitor;
 /**
  * Fake representation of a generic top-level type.
  */
-public class GenericMirror implements DeclaredType {
+public abstract class GenericMirror implements DeclaredType {
+
+  static GenericMirror create(
+      AtomicReference<GenericElement> element, Iterable<? extends TypeMirror> typeArguments) {
+    return Partial.of(GenericMirror.class, element, typeArguments);
+  }
 
   private final AtomicReference<GenericElement> element;
   private final ImmutableList<TypeMirror> typeArguments;

--- a/src/test/java/org/inferred/freebuilder/processor/util/NoTypes.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/NoTypes.java
@@ -22,12 +22,20 @@ import javax.lang.model.type.TypeVisitor;
 /**
  * Fake implementation of {@link NoType} for unit tests.
  */
-public enum NoTypes implements NoType {
-  NONE() {
-    @Override public TypeKind getKind() {
-      return TypeKind.NONE;
-    }
-  };
+public abstract class NoTypes implements NoType {
+
+  public static final NoType NONE = Partial.of(NoTypes.class, TypeKind.NONE);
+
+  private final TypeKind kind;
+
+  NoTypes(TypeKind kind) {
+    this.kind = kind;
+  }
+
+  @Override
+  public TypeKind getKind() {
+    return kind;
+  }
 
   @Override
   public <R, P> R accept(TypeVisitor<R, P> v, P p) {

--- a/src/test/java/org/inferred/freebuilder/processor/util/NullTypeImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/NullTypeImpl.java
@@ -19,11 +19,11 @@ import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeVisitor;
 
-public class NullTypeImpl implements NullType {
+public abstract class NullTypeImpl implements NullType {
 
-  public static final NullType NULL = new NullTypeImpl();
+  public static final NullType NULL = Partial.of(NullTypeImpl.class);
 
-  private NullTypeImpl() {}
+  NullTypeImpl() {}
 
   @Override
   public TypeKind getKind() {

--- a/src/test/java/org/inferred/freebuilder/processor/util/PackageElementImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/PackageElementImpl.java
@@ -15,15 +15,9 @@
  */
 package org.inferred.freebuilder.processor.util;
 
-import java.lang.annotation.Annotation;
-import java.util.List;
-import java.util.Set;
-
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ElementVisitor;
-import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.type.NoType;
@@ -31,11 +25,15 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVisitor;
 
-public class PackageElementImpl implements PackageElement {
+public abstract class PackageElementImpl implements PackageElement {
+
+  public static PackageElementImpl create(String qualifiedName) {
+    return Partial.of(PackageElementImpl.class, qualifiedName);
+  }
 
   private final String qualifiedName;
 
-  public PackageElementImpl(String qualifiedName) {
+  PackageElementImpl(String qualifiedName) {
     this.qualifiedName = qualifiedName;
   }
 
@@ -57,7 +55,7 @@ public class PackageElementImpl implements PackageElement {
 
   @Override
   public TypeMirror asType() {
-    return new PackageTypeImpl();
+    return Partial.of(PackageTypeImpl.class, qualifiedName);
   }
 
   @Override
@@ -66,28 +64,8 @@ public class PackageElementImpl implements PackageElement {
   }
 
   @Override
-  public List<? extends AnnotationMirror> getAnnotationMirrors() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Set<Modifier> getModifiers() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public <R, P> R accept(ElementVisitor<R, P> v, P p) {
     return v.visitPackage(this, p);
-  }
-
-  @Override
-  public List<? extends Element> getEnclosedElements() {
-    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -111,7 +89,13 @@ public class PackageElementImpl implements PackageElement {
     return false;
   }
 
-  class PackageTypeImpl implements NoType {
+  abstract static class PackageTypeImpl implements NoType {
+
+    private final String qualifiedName;
+
+    private PackageTypeImpl(String qualifiedName) {
+      this.qualifiedName = qualifiedName;
+    }
 
     @Override
     public TypeKind getKind() {


### PR DESCRIPTION
Fix three issues preventing us testing against JDK 8:

1. Many test double classes were implementing interfaces that have had extra methods added to in Java 8. Fixed with proxies.
2. sorcerer-javac (a JDK 7 compiler) was unintentionally being put on the classpath when unit testing, which was causing JAR version errors when testing with JDK 8. Fixed by explicitly excluding it in the POM (apparently there is no "stage" which does this by default).
3. Issue 2 was hiding a bug where an optimisation is not triggered during unit testing due to classloader issues, causing the associated test to fail. Fixed by moving the tests to the integration test suite, which does not have this issue. (Note that the integration test suite no longer passes under Eclipse, as it uses a different compiler, which this optimisation does not support. This should also have been true for the old unit tests, except that sorceror-javac masked the problem.)

This fixes #71.