### PR TITLE
Fix JavaDoc errors issued by javac 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
-script: mvn integration-test
+script: mvn verify
 jdk:
   - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,34 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -312,34 +340,6 @@
       <id>release</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/src/main/java/org/inferred/freebuilder/FreeBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/FreeBuilder.java
@@ -31,23 +31,23 @@ import java.lang.annotation.Target;
  * class, and it will automatically generate an implementing class and a package-visible builder API
  * ({@code Person_Builder}), which you must subclass. For instance:
  *
- * <p><blockquote><pre> {@literal @}FreeBuilder
+ * <blockquote><pre>&#64;FreeBuilder
  * public interface Person {
- *   /** Returns the person's full (English) name. *{@literal /}
+ *   /** Returns the person's full (English) name. *&#47;
  *   String getName();
- *   /** Returns the person's age in years, rounded down. *{@literal /}
+ *   /** Returns the person's age in years, rounded down. *&#47;
  *   int getAge();
- *   /** Builder of {{@literal @}link Person} instances. *{@literal /}
+ *   /** Builder of {&#64;link Person} instances. *&#47;
  *   class Builder extends Person_Builder { }
  * }</pre></blockquote>
  *
  * <p>You can now use the {@code Builder} class:
  *
- * <p><blockquote><pre> Person person = new Person.Builder()
+ * <blockquote><pre>Person person = new Person.Builder()
  *     .setName("Phil")
  *     .setAge(31)
  *     .build();
- * System.out.println(person);  // Person{name=Phil, age=31}</pre></blockquote></p>
+ * System.out.println(person);  // Person{name=Phil, age=31}</pre></blockquote>
  *
  * @see
  * <a href="http://freebuilder.inferred.org/">Full documentation at freebuilder.inferred.org</a>

--- a/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
@@ -67,7 +67,7 @@ public class ParameterizedType extends ValueType implements Excerpt {
   }
 
   /**
-   * Returns a new {@link TypeParameters} of the same length as this type, filled with wildcards
+   * Returns a new {@link ParameterizedType} of the same length as this type, filled with wildcards
    * ("?").
    */
   public ParameterizedType withWildcards() {
@@ -97,7 +97,7 @@ public class ParameterizedType extends ValueType implements Excerpt {
   }
 
   /**
-   * Returns a source excerpt suitable for declaring this type, i.e. SimpleName<...>
+   * Returns a source excerpt suitable for declaring this type, i.e. {@code SimpleName<...>}
    */
   public Excerpt declaration() {
     return new Excerpt() {

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
@@ -17,14 +17,15 @@ package org.inferred.freebuilder.processor.util;
 
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 
 /**
  * Source code builder, using format strings for readability, with sensible formatting for
  * type objects.
  *
- * <pre><code>
+ * <pre>
  * // Imports StringBuilder and appends "  StringBuilder foo;\n" to the source code.
- * builder.addLine("  %s foo;", StringBuilder.class);</pre></code>
+ * builder.addLine("  %s foo;", StringBuilder.class);</pre>
  */
 public interface SourceBuilder {
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceLevel.java
@@ -24,8 +24,8 @@ import com.google.common.base.Optional;
  *
  * <p>{@link SourceVersion} is problematic to use, as the constants themselves will be missing
  * on compilers that do not support them (e.g. "RELEASE_8" is not available on javac v6 or v7).
- * Additionally, "sourceLevel.supportsDiamondOperator()" is far more readable than
- * "sourceVersion.compareTo(SourceLevel.RELEASE_7) >= 0".
+ * Additionally, {@code sourceLevel.supportsDiamondOperator()} is far more readable than
+ * {@code sourceVersion.compareTo(SourceLevel.RELEASE_7) >= 0}.
  */
 public enum SourceLevel {
   JAVA_6, JAVA_7;


### PR DESCRIPTION
To avoid these issues in future, this change also makes JavaDoc validation part of the CI run.