### PR TITLE
Add remove and removeAll methods for multimaps

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
@@ -47,6 +47,8 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
 
   private static final String PUT_PREFIX = "put";
   private static final String PUT_ALL_PREFIX = "putAll";
+  private static final String REMOVE_PREFIX = "remove";
+  private static final String REMOVE_ALL_PREFIX = "removeAll";
   private static final String CLEAR_PREFIX = "clear";
   private static final String GET_PREFIX = "get";
 
@@ -191,6 +193,69 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
           .addLine("    %s%s(entry.getKey(), entry.getValue());",
               PUT_ALL_PREFIX, property.getCapitalizedName())
           .addLine("  }")
+          .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+
+      // remove(K key, V value)
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Removes a single key-value pair with the key {@code key} and the value"
+              + " {@code value}")
+          .addLine(" * from the multimap to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" * If multiple key-value pairs in the multimap fit this description, which one")
+          .addLine(" * is removed is unspecified.")
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+      if (!unboxedKeyType.isPresent() || !unboxedValueType.isPresent()) {
+        code.add(" * @throws NullPointerException if ");
+        if (unboxedKeyType.isPresent()) {
+          code.add("{@code value}");
+        } else if (unboxedValueType.isPresent()) {
+          code.add("{@code key}");
+        } else {
+          code.add("either {@code key} or {@code value}");
+        }
+        code.add(" is null\n");
+      }
+      code.addLine(" */")
+          .addLine("public %s %s%s(%s key, %s value) {",
+              metadata.getBuilder(),
+              REMOVE_PREFIX,
+              property.getCapitalizedName(),
+              unboxedKeyType.or(keyType),
+              unboxedValueType.or(valueType));
+      if (!unboxedKeyType.isPresent()) {
+        code.addLine("  %s.checkNotNull(key);", Preconditions.class);
+      }
+      if (!unboxedValueType.isPresent()) {
+        code.addLine("  %s.checkNotNull(value);", Preconditions.class);
+      }
+      code.addLine("  this.%s.remove(key, value);", property.getName())
+          .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+
+      // removeAll(K key)
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Removes all values associated with the key {@code key} from the multimap to")
+          .addLine(" * be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+      if (!unboxedKeyType.isPresent()) {
+        code.add(" * @throws NullPointerException if {@code key} is null\n");
+      }
+      code.addLine(" */")
+          .addLine("public %s %s%s(%s key) {",
+              metadata.getBuilder(),
+              REMOVE_ALL_PREFIX,
+              property.getCapitalizedName(),
+              unboxedKeyType.or(keyType));
+      if (!unboxedKeyType.isPresent()) {
+        code.addLine("  %s.checkNotNull(key);", Preconditions.class);
+      }
+      code.addLine("  this.%s.removeAll(key);", property.getName())
           .addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");
 

--- a/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
@@ -46,6 +46,8 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
 
   private static final String PUT_PREFIX = "put";
   private static final String PUT_ALL_PREFIX = "putAll";
+  private static final String REMOVE_PREFIX = "remove";
+  private static final String REMOVE_ALL_PREFIX = "removeAll";
   private static final String CLEAR_PREFIX = "clear";
   private static final String GET_PREFIX = "get";
 
@@ -192,6 +194,67 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
           .addLine("    %s%s(entry.getKey(), entry.getValue());",
               PUT_ALL_PREFIX, property.getCapitalizedName())
           .addLine("  }")
+          .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+
+      // remove(K key, V value)
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Removes a single key-value pair with the key {@code key} and the value"
+              + " {@code value}")
+          .addLine(" * from the multimap to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+      if (!unboxedKeyType.isPresent() || !unboxedValueType.isPresent()) {
+        code.add(" * @throws NullPointerException if ");
+        if (unboxedKeyType.isPresent()) {
+          code.add("{@code value}");
+        } else if (unboxedValueType.isPresent()) {
+          code.add("{@code key}");
+        } else {
+          code.add("either {@code key} or {@code value}");
+        }
+        code.add(" is null\n");
+      }
+      code.addLine(" */")
+          .addLine("public %s %s%s(%s key, %s value) {",
+              metadata.getBuilder(),
+              REMOVE_PREFIX,
+              property.getCapitalizedName(),
+              unboxedKeyType.or(keyType),
+              unboxedValueType.or(valueType));
+      if (!unboxedKeyType.isPresent()) {
+        code.addLine("  %s.checkNotNull(key);", Preconditions.class);
+      }
+      if (!unboxedValueType.isPresent()) {
+        code.addLine("  %s.checkNotNull(value);", Preconditions.class);
+      }
+      code.addLine("  this.%s.remove(key, value);", property.getName())
+          .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+
+      // removeAll(K key)
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Removes all values associated with the key {@code key} from the multimap to")
+          .addLine(" * be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+      if (!unboxedKeyType.isPresent()) {
+        code.add(" * @throws NullPointerException if {@code key} is null\n");
+      }
+      code.addLine(" */")
+          .addLine("public %s %s%s(%s key) {",
+              metadata.getBuilder(),
+              REMOVE_ALL_PREFIX,
+              property.getCapitalizedName(),
+              unboxedKeyType.or(keyType));
+      if (!unboxedKeyType.isPresent()) {
+        code.addLine("  %s.checkNotNull(key);", Preconditions.class);
+      }
+      code.addLine("  this.%s.removeAll(key);", property.getName())
           .addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");
 

--- a/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
@@ -573,6 +573,27 @@ public class ListMultimapPropertyFactoryTest {
   }
 
   @Test
+  public void testRemove_doesNotThrowIfEntryNotPresent() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \"A\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeItems(\"one\", \"Blue\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testRemove_primitiveKey() {
     behaviorTester
         .with(new Processor())
@@ -676,6 +697,24 @@ public class ListMultimapPropertyFactoryTest {
             .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
             .addLine("        \"one\", \"A\",")
             .addLine("        \"one\", \"Blue\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeAllItems(\"one\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_doesNotThrowIfKeyNotPresent() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
             .addLine("        \"two\", \"Blue\"))")
             .addLine("    .removeAllItems(\"one\")")
             .addLine("    .build();")

--- a/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
@@ -551,6 +551,216 @@ public class ListMultimapPropertyFactoryTest {
   }
 
   @Test
+  public void testRemove() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \"A\",")
+            .addLine("        \"one\", \"Blue\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeItems(\"one\", \"Blue\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_primitiveKey() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_KEY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \"A\",")
+            .addLine("        1, \"Blue\",")
+            .addLine("        2, \"Blue\"))")
+            .addLine("    .removeItems(1, \"Blue\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(1, \"A\")")
+            .addLine("    .and(2, \"Blue\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_primitiveValue() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_VALUE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \'A\',")
+            .addLine("        \"one\", \'B\',")
+            .addLine("        \"two\", \'B\'))")
+            .addLine("    .removeItems(\"one\", \'B\')")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \'A\')")
+            .addLine("    .and(\"two\", \'B\')")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_primitives() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVES)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \'A\',")
+            .addLine("        1, \'B\',")
+            .addLine("        2, \'B\'))")
+            .addLine("    .removeItems(1, \'B\')")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(1, \'A\')")
+            .addLine("    .and(2, \'B\')")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_nullKey() {
+    thrown.expect(NullPointerException.class);
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .removeItems((String) null, \"A\");")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_nullValue() {
+    thrown.expect(NullPointerException.class);
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .removeItems(\"one\", (String) null);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \"A\",")
+            .addLine("        \"one\", \"Blue\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeAllItems(\"one\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_primitiveKey() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_KEY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \"A\",")
+            .addLine("        1, \"Blue\",")
+            .addLine("        2, \"Blue\"))")
+            .addLine("    .removeAllItems(1)")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(2, \"Blue\")")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_primitiveValue() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_VALUE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \'A\',")
+            .addLine("        \"one\", \'B\',")
+            .addLine("        \"two\", \'B\'))")
+            .addLine("    .removeAllItems(\"one\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"two\", \'B\')")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_primitives() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVES)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \'A\',")
+            .addLine("        1, \'B\',")
+            .addLine("        2, \'B\'))")
+            .addLine("    .removeAllItems(1)")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(2, \'B\')")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_nullKey() {
+    thrown.expect(NullPointerException.class);
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .removeAllItems((String) null);")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testClear() {
     behaviorTester
         .with(new Processor())

--- a/src/test/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactoryTest.java
@@ -547,6 +547,216 @@ public class SetMultimapPropertyFactoryTest {
   }
 
   @Test
+  public void testRemove() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \"A\",")
+            .addLine("        \"one\", \"Blue\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeItems(\"one\", \"Blue\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_primitiveKey() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_KEY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \"A\",")
+            .addLine("        1, \"Blue\",")
+            .addLine("        2, \"Blue\"))")
+            .addLine("    .removeItems(1, \"Blue\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(1, \"A\")")
+            .addLine("    .and(2, \"Blue\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_primitiveValue() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_VALUE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \'A\',")
+            .addLine("        \"one\", \'B\',")
+            .addLine("        \"two\", \'B\'))")
+            .addLine("    .removeItems(\"one\", \'B\')")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \'A\')")
+            .addLine("    .and(\"two\", \'B\')")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_primitives() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVES)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \'A\',")
+            .addLine("        1, \'B\',")
+            .addLine("        2, \'B\'))")
+            .addLine("    .removeItems(1, \'B\')")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(1, \'A\')")
+            .addLine("    .and(2, \'B\')")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_nullKey() {
+    thrown.expect(NullPointerException.class);
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .removeItems((String) null, \"A\");")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemove_nullValue() {
+    thrown.expect(NullPointerException.class);
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .removeItems(\"one\", (String) null);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \"A\",")
+            .addLine("        \"one\", \"Blue\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeAllItems(\"one\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_primitiveKey() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_KEY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \"A\",")
+            .addLine("        1, \"Blue\",")
+            .addLine("        2, \"Blue\"))")
+            .addLine("    .removeAllItems(1)")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(2, \"Blue\")")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_primitiveValue() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVE_VALUE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \'A\',")
+            .addLine("        \"one\", \'B\',")
+            .addLine("        \"two\", \'B\'))")
+            .addLine("    .removeAllItems(\"one\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"two\", \'B\')")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_primitives() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PRIMITIVES)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        1, \'A\',")
+            .addLine("        1, \'B\',")
+            .addLine("        2, \'B\'))")
+            .addLine("    .removeAllItems(1)")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(2, \'B\')")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_nullKey() {
+    thrown.expect(NullPointerException.class);
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .removeAllItems((String) null);")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testClear() {
     behaviorTester
         .with(new Processor())

--- a/src/test/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactoryTest.java
@@ -569,6 +569,27 @@ public class SetMultimapPropertyFactoryTest {
   }
 
   @Test
+  public void testRemove_doesNotThrowIfEntryNotPresent() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
+            .addLine("        \"one\", \"A\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeItems(\"one\", \"Blue\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testRemove_primitiveKey() {
     behaviorTester
         .with(new Processor())
@@ -672,6 +693,24 @@ public class SetMultimapPropertyFactoryTest {
             .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
             .addLine("        \"one\", \"A\",")
             .addLine("        \"one\", \"Blue\",")
+            .addLine("        \"two\", \"Blue\"))")
+            .addLine("    .removeAllItems(\"one\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"two\", \"Blue\")")
+            .addLine("    .andNothingElse();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testRemoveAll_doesNotThrowIfKeyNotPresent() {
+    behaviorTester
+        .with(new Processor())
+        .with(MULTIMAP_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(%s.of(", ImmutableMultimap.class)
             .addLine("        \"two\", \"Blue\"))")
             .addLine("    .removeAllItems(\"one\")")
             .addLine("    .build();")


### PR DESCRIPTION
Though leaving out the remove operations made a "cleaner" (i.e. smaller) Builder API, it also makes modifying existing value objects (via mergeFrom)—a common operation, it turns out—much more cumbersome. I think the trade-off of the extra methods is worth it.