### PR TITLE
Pull out Guava calls into PreconditionExcerpts

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -18,10 +18,30 @@ package org.inferred.freebuilder.processor;
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
+
 import static org.inferred.freebuilder.processor.Metadata.GET_CODE_GENERATOR;
 import static org.inferred.freebuilder.processor.Metadata.UnderrideLevel.ABSENT;
 import static org.inferred.freebuilder.processor.Metadata.UnderrideLevel.FINAL;
 import static org.inferred.freebuilder.processor.PropertyCodeGenerator.IS_TEMPLATE_REQUIRED_IN_CLEAR;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS;
+
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.Metadata.StandardMethod;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
+import org.inferred.freebuilder.processor.util.QualifiedName;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -30,24 +50,6 @@ import java.util.List;
 
 import javax.annotation.Generated;
 import javax.lang.model.element.TypeElement;
-
-import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.Metadata.StandardMethod;
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
-import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
-import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.QualifiedName;
-
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 /**
  * Code generation for the &#64;{@link FreeBuilder} annotation.
@@ -151,9 +153,8 @@ public class CodeGenerator {
     code.addLine(" */")
         .addLine("public %s build() {", metadata.getType());
     if (hasRequiredProperties) {
-      code.addLine(
-          "  %s.checkState(_unsetProperties.isEmpty(), \"Not set: %%s\", _unsetProperties);",
-          Preconditions.class);
+      code.add(PreconditionExcerpts.checkState(
+          IS, "_unsetProperties.isEmpty()", "Not set: %s", "_unsetProperties"));
     }
     code.addLine("  return %s(this);", metadata.getValueType().constructor())
         .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -23,7 +23,6 @@ import static org.inferred.freebuilder.processor.Metadata.GET_CODE_GENERATOR;
 import static org.inferred.freebuilder.processor.Metadata.UnderrideLevel.ABSENT;
 import static org.inferred.freebuilder.processor.Metadata.UnderrideLevel.FINAL;
 import static org.inferred.freebuilder.processor.PropertyCodeGenerator.IS_TEMPLATE_REQUIRED_IN_CLEAR;
-import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.VisibleForTesting;
@@ -154,7 +153,7 @@ public class CodeGenerator {
         .addLine("public %s build() {", metadata.getType());
     if (hasRequiredProperties) {
       code.add(PreconditionExcerpts.checkState(
-          IS, "_unsetProperties.isEmpty()", "Not set: %s", "_unsetProperties"));
+          "_unsetProperties.isEmpty()", "Not set: %s", "_unsetProperties"));
     }
     code.addLine("  return %s(this);", metadata.getValueType().constructor())
         .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
@@ -17,7 +17,6 @@ package org.inferred.freebuilder.processor;
 
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
-import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS_NOT;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -128,15 +127,14 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
       }
       code.addLine("public %s %s() {", property.getType(), property.getGetterName());
       if (!hasDefault) {
-        Excerpt condition = new Excerpt() {
+        Excerpt propertyIsSet = new Excerpt() {
           @Override
           public void addTo(SourceBuilder source) {
-            source.add("_unsetProperties.contains(%s.%s)",
+            source.add("!_unsetProperties.contains(%s.%s)",
                 metadata.getPropertyEnum(), property.getAllCapsName());
           }
         };
-        code.add(PreconditionExcerpts.checkState(
-            IS_NOT, condition, property.getName() + " not set"));
+        code.add(PreconditionExcerpts.checkState(propertyIsSet, property.getName() + " not set"));
       }
       code.addLine("  return %s;", property.getName())
           .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
@@ -15,15 +15,20 @@
  */
 package org.inferred.freebuilder.processor;
 
-import javax.lang.model.element.TypeElement;
-
-import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
-import org.inferred.freebuilder.processor.util.SourceBuilder;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS_NOT;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
+
+import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import javax.lang.model.element.TypeElement;
 
 /** Default {@link PropertyCodeGenerator.Factory}, providing reference semantics for any type. */
 public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
@@ -73,7 +78,7 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code, final Metadata metadata) {
       // Setter
       code.addLine("")
           .addLine("/**")
@@ -94,8 +99,8 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
       if (isNullable || isPrimitive) {
         code.addLine("  this.%1$s = %1$s;", property.getName());
       } else {
-        code.addLine("  this.%1$s = %2$s.checkNotNull(%1$s);",
-            property.getName(), Preconditions.class);
+        code.add("%s", checkNotNullPreamble(property.getName()))
+            .addLine("  this.%s = %s;", property.getName(), checkNotNullInline(property.getName()));
       }
       if (!hasDefault) {
         code.addLine("  _unsetProperties.remove(%s.%s);",
@@ -123,10 +128,15 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
       }
       code.addLine("public %s %s() {", property.getType(), property.getGetterName());
       if (!hasDefault) {
-        code.addLine("  %s.checkState(", Preconditions.class)
-            .addLine("      !_unsetProperties.contains(%s.%s),",
-                metadata.getPropertyEnum(), property.getAllCapsName())
-            .addLine("      \"%s not set\");", property.getName());
+        Excerpt condition = new Excerpt() {
+          @Override
+          public void addTo(SourceBuilder source) {
+            source.add("_unsetProperties.contains(%s.%s)",
+                metadata.getPropertyEnum(), property.getAllCapsName());
+          }
+        };
+        code.add(PreconditionExcerpts.checkState(
+            IS_NOT, condition, property.getName() + " not set"));
       }
       code.addLine("  return %s;", property.getName())
           .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
@@ -17,6 +17,16 @@ package org.inferred.freebuilder.processor;
 
 import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,15 +36,6 @@ import java.util.List;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-
-import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
-import org.inferred.freebuilder.processor.util.SourceBuilder;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 /**
  * {@link PropertyCodeGenerator.Factory} providing append-only semantics for {@link List}
@@ -112,8 +113,8 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
       if (unboxedType.isPresent()) {
         code.addLine("  this.%s.add(element);", property.getName());
       } else {
-        code.addLine("  this.%s.add(%s.checkNotNull(element));",
-            property.getName(), Preconditions.class);
+        code.add(checkNotNullPreamble("element"))
+            .addLine("  this.%s.add(%s);", property.getName(), checkNotNullInline("element"));
       }
       code.addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
@@ -17,8 +17,6 @@ package org.inferred.freebuilder.processor;
 
 import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
-import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS;
-import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS_NOT;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -138,14 +136,14 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
       if (!unboxedValueType.isPresent()) {
         code.add(PreconditionExcerpts.checkNotNull("value"));
       }
-      Excerpt containsKey = new Excerpt() {
+      Excerpt keyNotPresent = new Excerpt() {
         @Override
         public void addTo(SourceBuilder source) {
-          source.add("%s.containsKey(key)", property.getName());
+          source.add("!%s.containsKey(key)", property.getName());
         }
       };
       code.add(PreconditionExcerpts.checkArgument(
-              IS_NOT, containsKey, "Key already present in " + property.getName() + ": %s", "key"))
+              keyNotPresent, "Key already present in " + property.getName() + ": %s", "key"))
           .addLine("  %s.put(key, value);", property.getName())
           .addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");
@@ -199,8 +197,14 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
       if (!unboxedKeyType.isPresent()) {
         code.add(PreconditionExcerpts.checkNotNull("key"));
       }
+      Excerpt keyPresent = new Excerpt() {
+        @Override
+        public void addTo(SourceBuilder source) {
+          source.add("%s.containsKey(key)", property.getName());
+        }
+      };
       code.add(PreconditionExcerpts.checkArgument(
-              IS, containsKey, "Key not present in " + property.getName() + ": %s", "key"))
+              keyPresent, "Key not present in " + property.getName() + ": %s", "key"))
           .addLine("  %s.remove(key);", property.getName())
           .addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
@@ -17,6 +17,16 @@ package org.inferred.freebuilder.processor;
 
 import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+
+import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -25,15 +35,6 @@ import java.util.Set;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-
-import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
-import org.inferred.freebuilder.processor.util.SourceBuilder;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * {@link PropertyCodeGenerator.Factory} providing append-only semantics for {@link Set}
@@ -114,8 +115,8 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
       if (unboxedType.isPresent()) {
         code.addLine("  this.%s.add(element);", property.getName());
       } else {
-        code.addLine("  this.%s.add(%s.checkNotNull(element));",
-            property.getName(), Preconditions.class);
+        code.add(checkNotNullPreamble("element"))
+            .addLine("  this.%s.add(%s);", property.getName(), checkNotNullInline("element"));
       }
       code.addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitWriter.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitWriter.java
@@ -90,6 +90,12 @@ public class CompilationUnitWriter implements SourceBuilder, Closeable {
   }
 
   @Override
+  public SourceBuilder add(Excerpt excerpt) {
+    source.add(excerpt);
+    return this;
+  }
+
+  @Override
   public CompilationUnitWriter addLine(String fmt, Object... args) {
     source.addLine(fmt, args);
     return this;

--- a/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
@@ -13,21 +13,6 @@ public class PreconditionExcerpts {
       Escapers.builder().addEscape('"', "\"").build();
 
   /**
-   * Whether to check that a condition {@code IS} or {@code IS_NOT} true.
-   *
-   * <p>Lets us generate code without double negatives (i.e. '!!')
-   */
-  public static enum StateCondition {
-    IS(""), IS_NOT("!");
-
-    private final String trueIfConditionHolds;
-
-    private StateCondition(String trueIfConditionHolds) {
-      this.trueIfConditionHolds = trueIfConditionHolds;
-    }
-  }
-
-  /**
    * Returns an excerpt of the preamble required to emulate an inline call to Guava's
    * {@link Preconditions#checkNotNull(Object)} method.
    *
@@ -93,24 +78,19 @@ public class PreconditionExcerpts {
    *
    * <pre>code.add(checkArgument(IS, "age >= 0", "age must be non-negative (got %s)", "age"));</pre>
    *
-   * @param isOrIsNot whether to negate {@code condition} or not
    * @param condition an excerpt containing the expression to pass to the checkArgument method
    * @param message the error message template to pass to the checkArgument method
    * @param args excerpts containing the error message arguments to pass to the checkArgument method
    */
   public static Excerpt checkArgument(
-      final StateCondition isOrIsNot,
       final Object condition,
       final String message,
       final Object... args) {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        code.add("%s.checkArgument(%s%s, \"%s\"",
-            Preconditions.class,
-            isOrIsNot.trueIfConditionHolds,
-            condition,
-            JAVA_STRING_ESCAPER.escape(message));
+        code.add("%s.checkArgument(%s, \"%s\"",
+            Preconditions.class, condition, JAVA_STRING_ESCAPER.escape(message));
         for (Object arg : args) {
           code.add(", %s", arg);
         }
@@ -126,22 +106,19 @@ public class PreconditionExcerpts {
    * <pre>code.add(checkState(IS, "start < end",
    *        "start must be before end (got %s and %s)", "start", "end"));</pre>
    *
-   * @param isOrIsNot whether to negate {@code condition} or not
    * @param condition an excerpt containing the expression to pass to the checkState method
    * @param message the error message template to pass to the checkState method
    * @param args excerpts containing the error message arguments to pass to the checkState method
    */
   public static Excerpt checkState(
-      final StateCondition isOrIsNot,
       final Object condition,
       final String message,
       final Object... args) {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        code.add("%s.checkState(%s%s, \"%s\"",
+        code.add("%s.checkState(%s, \"%s\"",
             Preconditions.class,
-            isOrIsNot.trueIfConditionHolds,
             condition,
             JAVA_STRING_ESCAPER.escape(message));
         for (Object arg : args) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
@@ -1,0 +1,146 @@
+package org.inferred.freebuilder.processor.util;
+
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS;
+
+import com.google.common.base.Preconditions;
+import com.google.common.escape.Escaper;
+import com.google.common.escape.Escapers;
+
+/**
+ * Code snippets that call or emulate Guava's {@link Preconditions} methods.
+ */
+public class PreconditionExcerpts {
+
+  private static final Escaper JAVA_STRING_ESCAPER =
+      Escapers.builder().addEscape('"', "\"").build();
+
+  public static enum StateCondition {
+    IS, IS_NOT
+  }
+
+  /**
+   * Returns an excerpt of the preamble required to emulate an inline call to Guava's
+   * {@link Preconditions#checkNotNull(Object)} method.
+   *
+   * <p>If you use this, you <b>must</b> also use {@link #checkNotNullInline} to perform the check
+   * inline when possible.
+   */
+  public static Excerpt checkNotNullPreamble(final Object reference) {
+    return new Excerpt() {
+      @Override
+      public void addTo(SourceBuilder code) {
+        // No preamble needed
+      }
+    };
+  }
+
+  /**
+   * Returns an excerpt equivalent to an inline call to Guava's
+   * {@link Preconditions#checkNotNull(Object)}:
+   *
+   * <p>If you use this, you <b>must</b> also use {@link #checkNotNullPreamble} to perform the
+   * out-of-line check if necessary.
+   *
+   * @param reference an excerpt containing the reference to pass to the checkNotNull method
+   */
+  public static Excerpt checkNotNullInline(final Object reference) {
+    return new Excerpt() {
+      @Override
+      public void addTo(SourceBuilder code) {
+        code.add("%s.checkNotNull(%s)", Preconditions.class, reference);
+      }
+    };
+  }
+
+  /**
+   * Returns an excerpt equivalent to a call to Guava's
+   * {@link Preconditions#checkNotNull(Object)}:
+   *
+   * @param reference an excerpt containing the reference to pass to the checkNotNull method
+   */
+  public static Excerpt checkNotNull(final Object reference) {
+    return new Excerpt() {
+      @Override
+      public void addTo(SourceBuilder code) {
+        code.addLine("%s.checkNotNull(%s);", Preconditions.class, reference);
+      }
+    };
+  }
+
+  /**
+   * Returns an excerpt equivalent to Guava's
+   * {@link Preconditions#checkArgument(boolean, String, Object...)}.
+   *
+   * @param isOrIsNot whether to negate {@code condition} or not
+   * @param condition an excerpt containing the expression to pass to the checkArgument method
+   * @param message the error message template to pass to the checkArgument method
+   * @param args excerpts containing the error message arguments to pass to the checkArgument method
+   */
+  public static Excerpt checkArgument(
+      final StateCondition isOrIsNot,
+      final Object condition,
+      final String message,
+      final Object... args) {
+    return new Excerpt() {
+      @Override
+      public void addTo(SourceBuilder code) {
+        boolean addNewlines = excerptIsLong(code, condition);
+        code.add("%s.checkArgument(%s%s%s,%s\"%s\"",
+            Preconditions.class,
+            addNewlines ? "\n" : "",
+            isOrIsNot == IS ? "" : "!",
+            condition,
+            addNewlines ? "\n" : " ",
+            JAVA_STRING_ESCAPER.escape(message));
+        for (Object arg : args) {
+          code.add(", %s", arg);
+        }
+        code.add(");\n");
+      }
+    };
+  }
+
+  /**
+   * Returns an excerpt equivalent to Guava's
+   * {@link Preconditions#checkState(boolean, String, Object...)}.
+   *
+   * @param isOrIsNot whether to negate {@code condition} or not
+   * @param condition an excerpt containing the expression to pass to the checkState method
+   * @param message the error message template to pass to the checkState method
+   * @param args excerpts containing the error message arguments to pass to the checkState method
+   */
+  public static Excerpt checkState(
+      final StateCondition isOrIsNot,
+      final Object condition,
+      final String message,
+      final Object... args) {
+    return new Excerpt() {
+      @Override
+      public void addTo(SourceBuilder code) {
+        boolean addNewlines = excerptIsLong(code, condition);
+        code.add("%s.checkState(%s%s%s,%s\"%s\"",
+            Preconditions.class,
+            addNewlines ? "\n" : "",
+            isOrIsNot == IS ? "" : "!",
+            condition,
+            addNewlines ? "\n" : " ",
+            JAVA_STRING_ESCAPER.escape(message));
+        for (Object arg : args) {
+          code.add(", %s", arg);
+        }
+        code.add(");\n");
+      }
+    };
+  }
+
+  private static boolean excerptIsLong(SourceBuilder code, final Object excerpt) {
+    String excerptAsString = SourceStringBuilder
+        .simple(code.getSourceLevel())
+        .add("%s", excerpt)
+        .toString();
+    boolean addNewlines = (excerptAsString.length() > 50);
+    return addNewlines;
+  }
+
+  private PreconditionExcerpts() {}
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
@@ -1,7 +1,5 @@
 package org.inferred.freebuilder.processor.util;
 
-import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.StateCondition.IS;
-
 import com.google.common.base.Preconditions;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
@@ -14,16 +12,32 @@ public class PreconditionExcerpts {
   private static final Escaper JAVA_STRING_ESCAPER =
       Escapers.builder().addEscape('"', "\"").build();
 
+  /**
+   * Whether to check that a condition {@code IS} or {@code IS_NOT} true.
+   *
+   * <p>Lets us generate code without double negatives (i.e. '!!')
+   */
   public static enum StateCondition {
-    IS, IS_NOT
+    IS(""), IS_NOT("!");
+
+    private final String trueIfConditionHolds;
+
+    private StateCondition(String trueIfConditionHolds) {
+      this.trueIfConditionHolds = trueIfConditionHolds;
+    }
   }
 
   /**
    * Returns an excerpt of the preamble required to emulate an inline call to Guava's
    * {@link Preconditions#checkNotNull(Object)} method.
    *
-   * <p>If you use this, you <b>must</b> also use {@link #checkNotNullInline} to perform the check
-   * inline when possible.
+   * <p>If you use this, you <b>must</b> also use {@link #checkNotNullInline} to allow the check to
+   * be performed inline when possible:
+   *
+   * <pre>code.add(checkNotNullPreamble("value"))
+   *    .addLine("this.property = %s;", checkNotNullInline("value"));</pre>
+   *
+   * @param reference an excerpt containing the reference to pass to the checkNotNull method
    */
   public static Excerpt checkNotNullPreamble(final Object reference) {
     return new Excerpt() {
@@ -36,10 +50,13 @@ public class PreconditionExcerpts {
 
   /**
    * Returns an excerpt equivalent to an inline call to Guava's
-   * {@link Preconditions#checkNotNull(Object)}:
+   * {@link Preconditions#checkNotNull(Object)}.
    *
-   * <p>If you use this, you <b>must</b> also use {@link #checkNotNullPreamble} to perform the
-   * out-of-line check if necessary.
+   * <p>If you use this, you <b>must</b> also use {@link #checkNotNullPreamble} to allow the
+   * check to be performed out-of-line if necessary:
+   *
+   * <pre>code.add(checkNotNullPreamble("value"))
+   *    .addLine("this.property = %s;", checkNotNullInline("value"));</pre>
    *
    * @param reference an excerpt containing the reference to pass to the checkNotNull method
    */
@@ -53,8 +70,11 @@ public class PreconditionExcerpts {
   }
 
   /**
-   * Returns an excerpt equivalent to a call to Guava's
-   * {@link Preconditions#checkNotNull(Object)}:
+   * Returns an excerpt equivalent to Guava's {@link Preconditions#checkNotNull(Object)}:
+   *
+   * <pre>code.add(checkNotNull("key"))
+   *    .add(checkNotNull("value"))
+   *    .addLine("map.put(key, value);");</pre>
    *
    * @param reference an excerpt containing the reference to pass to the checkNotNull method
    */
@@ -71,6 +91,8 @@ public class PreconditionExcerpts {
    * Returns an excerpt equivalent to Guava's
    * {@link Preconditions#checkArgument(boolean, String, Object...)}.
    *
+   * <pre>code.add(checkArgument(IS, "age >= 0", "age must be non-negative (got %s)", "age"));</pre>
+   *
    * @param isOrIsNot whether to negate {@code condition} or not
    * @param condition an excerpt containing the expression to pass to the checkArgument method
    * @param message the error message template to pass to the checkArgument method
@@ -84,13 +106,10 @@ public class PreconditionExcerpts {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        boolean addNewlines = excerptIsLong(code, condition);
-        code.add("%s.checkArgument(%s%s%s,%s\"%s\"",
+        code.add("%s.checkArgument(%s%s, \"%s\"",
             Preconditions.class,
-            addNewlines ? "\n" : "",
-            isOrIsNot == IS ? "" : "!",
+            isOrIsNot.trueIfConditionHolds,
             condition,
-            addNewlines ? "\n" : " ",
             JAVA_STRING_ESCAPER.escape(message));
         for (Object arg : args) {
           code.add(", %s", arg);
@@ -103,6 +122,9 @@ public class PreconditionExcerpts {
   /**
    * Returns an excerpt equivalent to Guava's
    * {@link Preconditions#checkState(boolean, String, Object...)}.
+   *
+   * <pre>code.add(checkState(IS, "start < end",
+   *        "start must be before end (got %s and %s)", "start", "end"));</pre>
    *
    * @param isOrIsNot whether to negate {@code condition} or not
    * @param condition an excerpt containing the expression to pass to the checkState method
@@ -117,13 +139,10 @@ public class PreconditionExcerpts {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        boolean addNewlines = excerptIsLong(code, condition);
-        code.add("%s.checkState(%s%s%s,%s\"%s\"",
+        code.add("%s.checkState(%s%s, \"%s\"",
             Preconditions.class,
-            addNewlines ? "\n" : "",
-            isOrIsNot == IS ? "" : "!",
+            isOrIsNot.trueIfConditionHolds,
             condition,
-            addNewlines ? "\n" : " ",
             JAVA_STRING_ESCAPER.escape(message));
         for (Object arg : args) {
           code.add(", %s", arg);
@@ -131,15 +150,6 @@ public class PreconditionExcerpts {
         code.add(");\n");
       }
     };
-  }
-
-  private static boolean excerptIsLong(SourceBuilder code, final Object excerpt) {
-    String excerptAsString = SourceStringBuilder
-        .simple(code.getSourceLevel())
-        .add("%s", excerpt)
-        .toString();
-    boolean addNewlines = (excerptAsString.length() > 50);
-    return addNewlines;
   }
 
   private PreconditionExcerpts() {}

--- a/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
@@ -76,7 +76,7 @@ public class PreconditionExcerpts {
    * Returns an excerpt equivalent to Guava's
    * {@link Preconditions#checkArgument(boolean, String, Object...)}.
    *
-   * <pre>code.add(checkArgument(IS, "age >= 0", "age must be non-negative (got %s)", "age"));</pre>
+   * <pre>code.add(checkArgument("age &gt;= 0", "age must be non-negative (got %s)", "age"));</pre>
    *
    * @param condition an excerpt containing the expression to pass to the checkArgument method
    * @param message the error message template to pass to the checkArgument method
@@ -103,8 +103,8 @@ public class PreconditionExcerpts {
    * Returns an excerpt equivalent to Guava's
    * {@link Preconditions#checkState(boolean, String, Object...)}.
    *
-   * <pre>code.add(checkState(IS, "start < end",
-   *        "start must be before end (got %s and %s)", "start", "end"));</pre>
+   * <pre>code.add(checkState("start &lt; end",
+   *         "start must be before end (got %s and %s)", "start", "end"));</pre>
    *
    * @param condition an excerpt containing the expression to pass to the checkState method
    * @param message the error message template to pass to the checkState method

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
@@ -57,5 +57,10 @@ public interface SourceBuilder {
    */
   SourceBuilder addLine(String fmt, Object... args);
 
+  /**
+   * Equivalent to {@code add("%s", excerpt)}.
+   */
+  SourceBuilder add(Excerpt excerpt);
+
   SourceLevel getSourceLevel();
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
@@ -51,6 +51,12 @@ public final class SourceStringBuilder implements SourceBuilder {
   }
 
   @Override
+  public SourceBuilder add(Excerpt excerpt) {
+    excerpt.addTo(this);
+    return this;
+  }
+
+  @Override
   public SourceBuilder add(String fmt, Object... args) {
     Object[] substituteArgs = new Object[args.length];
     for (int i = 0; i < args.length; i++) {


### PR DESCRIPTION
To remove Guava as a dependency (#87), we need idiomatic ways to perform checkNotNull, checkArgument and checkState calls in vanilla Java. To make this easier, first pull out the code writing the Guava calls into a common class.

Apologies for yet another round of random import reorderings :unamused: 