### PR TITLE
Ignore hidden Builders

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
@@ -17,6 +17,8 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.tryFind;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.util.ElementFilter.typesIn;
 import static org.inferred.freebuilder.processor.util.ModelUtils.findAnnotationMirror;
 
@@ -356,7 +358,8 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
 
   private static final Predicate<Element> IS_BUILDER_TYPE = new Predicate<Element>() {
     @Override public boolean apply(Element element) {
-      return element.getSimpleName().contentEquals("Builder");
+      return element.getSimpleName().contentEquals("Builder")
+          && element.getModifiers().contains(PUBLIC);
     }
   };
 


### PR DESCRIPTION
Don't treat types as buildable if their Builder class is not publicly visible. Otherwise, either illegal references or unusable getter/setter methods are generated.

This fixes #101.