### PR TITLE
Nice error for default package

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -143,8 +143,8 @@ class Analyser {
    * @throws CannotGenerateCodeException if code cannot be generated, e.g. if the type is private
    */
   Metadata analyse(TypeElement type) throws CannotGenerateCodeException {
-    verifyType(type);
     PackageElement pkg = elements.getPackageOf(type);
+    verifyType(type, pkg);
     ImmutableSet<ExecutableElement> methods = methodsOn(type, elements);
     QualifiedName generatedBuilder = QualifiedName.of(
         pkg.getQualifiedName().toString(), generatedBuilderSimpleName(type));
@@ -193,7 +193,11 @@ class Analyser {
   }
 
   /** Basic sanity-checking to ensure we can fulfil the &#64;FreeBuilder contract for this type. */
-  private void verifyType(TypeElement type) throws CannotGenerateCodeException {
+  private void verifyType(TypeElement type, PackageElement pkg) throws CannotGenerateCodeException {
+    if (pkg.isUnnamed()) {
+      messager.printMessage(ERROR, "@FreeBuilder does not support types in unnamed packages", type);
+      throw new CannotGenerateCodeException();
+    }
     switch (type.getNestingKind()) {
       case TOP_LEVEL:
         break;

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -1206,6 +1206,21 @@ public class AnalyserTest {
   }
 
   @Test
+  public void unnamedPackage() {
+    TypeElement dataType = model.newType(
+        "public class DataType {}");
+
+    try {
+      analyser.analyse(dataType);
+      fail("Expected CannotGenerateCodeException");
+    } catch (CannotGenerateCodeException expected) { }
+
+    assertThat(messager.getMessagesByElement().asMap())
+        .containsEntry("DataType", ImmutableList.of(
+            "[ERROR] @FreeBuilder does not support types in unnamed packages"));
+  }
+
+  @Test
   public void freeAnnotationBuilder() {
     TypeElement dataType = model.newType(
         "package com.example;",


### PR DESCRIPTION
Write out a nice error message if the user forgets the package declaration. This fixes #85.