### PR TITLE
Support generic features in SourceBuilder

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -23,6 +23,8 @@ import static org.inferred.freebuilder.processor.Metadata.GET_CODE_GENERATOR;
 import static org.inferred.freebuilder.processor.Metadata.UnderrideLevel.ABSENT;
 import static org.inferred.freebuilder.processor.Metadata.UnderrideLevel.FINAL;
 import static org.inferred.freebuilder.processor.PropertyCodeGenerator.IS_TEMPLATE_REQUIRED_IN_CLEAR;
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -103,7 +105,7 @@ public class CodeGenerator {
   }
 
   private static void addConstantDeclarations(Metadata metadata, SourceBuilder body) {
-    if (body.isGuavaAvailable() && metadata.getProperties().size() > 1) {
+    if (body.feature(GUAVA).isAvailable() && metadata.getProperties().size() > 1) {
       body.addLine("")
           .addLine("private static final %1$s COMMA_JOINER = %1$s.on(\", \").skipNulls();",
               Joiner.class);
@@ -257,7 +259,7 @@ public class CodeGenerator {
     code.addLine(" *")
         .addLine(" * <p>Partials should only ever be used in tests.")
         .addLine(" */");
-    if (code.isGuavaAvailable()) {
+    if (code.feature(GUAVA).isAvailable()) {
       code.addLine("@%s()", VisibleForTesting.class);
     }
     code.addLine("public %s buildPartial() {", metadata.getType())
@@ -337,12 +339,12 @@ public class CodeGenerator {
             .addLine("    %1$s other = (%1$s) obj;", metadata.getValueType().withWildcards());
         if (metadata.getProperties().isEmpty()) {
           code.addLine("    return true;");
-        } else if (code.getSourceLevel().javaUtilObjects().isPresent()) {
+        } else if (code.feature(SOURCE_LEVEL).javaUtilObjects().isPresent()) {
           String prefix = "    return ";
           for (Property property : metadata.getProperties()) {
             code.add(prefix);
             code.add("%1$s.equals(%2$s, other.%2$s)",
-                code.getSourceLevel().javaUtilObjects().get(), property.getName());
+                code.feature(SOURCE_LEVEL).javaUtilObjects().get(), property.getName());
             prefix = "\n        && ";
           }
           code.add(";\n");
@@ -395,9 +397,9 @@ public class CodeGenerator {
       code.addLine("")
           .addLine("  @%s", Override.class)
           .addLine("  public int hashCode() {");
-      if (code.getSourceLevel().javaUtilObjects().isPresent()) {
+      if (code.feature(SOURCE_LEVEL).javaUtilObjects().isPresent()) {
         code.addLine("    return %s.hash(%s);",
-            code.getSourceLevel().javaUtilObjects().get(), properties);
+            code.feature(SOURCE_LEVEL).javaUtilObjects().get(), properties);
       } else {
         code.addLine("    return %s.hashCode(new Object[] { %s });", Arrays.class, properties);
       }
@@ -528,18 +530,18 @@ public class CodeGenerator {
           .addLine("    %1$s other = (%1$s) obj;", metadata.getPartialType().withWildcards());
       if (metadata.getProperties().isEmpty()) {
         code.addLine("    return true;");
-      } else if (code.getSourceLevel().javaUtilObjects().isPresent()) {
+      } else if (code.feature(SOURCE_LEVEL).javaUtilObjects().isPresent()) {
         String prefix = "    return ";
         for (Property property : metadata.getProperties()) {
           code.add(prefix);
           code.add("%1$s.equals(%2$s, other.%2$s)",
-              code.getSourceLevel().javaUtilObjects().get(), property.getName());
+              code.feature(SOURCE_LEVEL).javaUtilObjects().get(), property.getName());
           prefix = "\n        && ";
         }
         if (hasRequiredProperties) {
           code.add(prefix);
           code.add("%1$s.equals(_unsetProperties, other._unsetProperties)",
-              code.getSourceLevel().javaUtilObjects().get());
+              code.feature(SOURCE_LEVEL).javaUtilObjects().get());
         }
         code.add(";\n");
       } else {
@@ -587,9 +589,9 @@ public class CodeGenerator {
       }
       String properties = Joiner.on(", ").join(namesList);
 
-      if (code.getSourceLevel().javaUtilObjects().isPresent()) {
+      if (code.feature(SOURCE_LEVEL).javaUtilObjects().isPresent()) {
         code.addLine("    return %s.hash(%s);",
-            code.getSourceLevel().javaUtilObjects().get(), properties);
+            code.feature(SOURCE_LEVEL).javaUtilObjects().get(), properties);
       } else {
         code.addLine("    return %s.hashCode(new Object[] { %s });", Arrays.class, properties);
       }
@@ -600,7 +602,7 @@ public class CodeGenerator {
       code.addLine("")
           .addLine("  @%s", Override.class)
           .addLine("  public %s toString() {", String.class);
-      if (metadata.getProperties().size() > 1 && !code.isGuavaAvailable()) {
+      if (metadata.getProperties().size() > 1 && !code.feature(GUAVA).isAvailable()) {
         writePartialToStringWithBuilder(code, metadata);
       } else {
         writePartialToStringWithConcatenation(code, metadata);

--- a/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
@@ -19,6 +19,8 @@ import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -94,7 +96,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
           ArrayList.class,
           elementType,
           property.getName(),
-          code.getSourceLevel().supportsDiamondOperator() ? "" : elementType);
+          code.feature(SOURCE_LEVEL).supportsDiamondOperator() ? "" : elementType);
     }
 
     @Override
@@ -209,7 +211,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
 
     @Override
     public void addFinalFieldAssignment(SourceBuilder code, String finalField, String builder) {
-      if (code.isGuavaAvailable()) {
+      if (code.feature(GUAVA).isAvailable()) {
         code.addLine("%s = %s.copyOf(%s.%s);",
             finalField, ImmutableList.class, builder, property.getName());
       } else {
@@ -265,7 +267,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
     IMMUTABLE_LIST() {
       @Override
       public void addTo(SourceBuilder code) {
-        if (!code.isGuavaAvailable()) {
+        if (!code.feature(GUAVA).isAvailable()) {
           code.addLine("")
               .addLine("@%s(\"unchecked\")", SuppressWarnings.class)
               .addLine("private static <E> %1$s<E> immutableList(%1$s<E> elements, %2$s<E> type) {",

--- a/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
@@ -17,6 +17,8 @@ package org.inferred.freebuilder.processor;
 
 import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -97,7 +99,7 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
     public void addBuilderFieldDeclaration(SourceBuilder code) {
       code.add("private final %1$s<%2$s, %3$s> %4$s = new %1$s<",
           LinkedHashMap.class, keyType, valueType, property.getName());
-      if (!code.getSourceLevel().supportsDiamondOperator()) {
+      if (!code.feature(SOURCE_LEVEL).supportsDiamondOperator()) {
         code.add("%s, %s", keyType, valueType);
       }
       code.add(">();\n");
@@ -247,7 +249,7 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
     @Override
     public void addFinalFieldAssignment(SourceBuilder code, String finalField, String builder) {
       code.add("%s = ", finalField);
-      if (code.isGuavaAvailable()) {
+      if (code.feature(GUAVA).isAvailable()) {
         code.add("%s.copyOf", ImmutableMap.class);
       } else {
         code.add("immutableMap");
@@ -312,7 +314,7 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
     IMMUTABLE_MAP() {
       @Override
       public void addTo(SourceBuilder code) {
-        if (!code.isGuavaAvailable()) {
+        if (!code.feature(GUAVA).isAvailable()) {
           code.addLine("")
               .addLine("private static <K, V> %1$s<K, V> immutableMap(%1$s<K, V> entries) {",
                   Map.class)
@@ -326,7 +328,7 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
                   Collections.class)
               .addLine("  default:")
               .add("    return %s.unmodifiableMap(new %s<", Collections.class, LinkedHashMap.class);
-          if (!code.getSourceLevel().supportsDiamondOperator()) {
+          if (!code.feature(SOURCE_LEVEL).supportsDiamondOperator()) {
             code.add("K, V");
           }
           code.add(">(entries));\n")

--- a/src/main/java/org/inferred/freebuilder/processor/Processor.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Processor.java
@@ -15,9 +15,17 @@
  */
 package org.inferred.freebuilder.processor;
 
-import static javax.lang.model.util.ElementFilter.typesIn;
 import static org.inferred.freebuilder.processor.util.ModelUtils.findAnnotationMirror;
 import static org.inferred.freebuilder.processor.util.RoundEnvironments.annotatedElementsIn;
+
+import static javax.lang.model.util.ElementFilter.typesIn;
+
+import com.google.auto.service.AutoService;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.CompilationUnitWriter;
 
 import java.util.Set;
 
@@ -28,16 +36,6 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
-
-import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.CompilationUnitWriter;
-import org.inferred.freebuilder.processor.util.Shading;
-import org.inferred.freebuilder.processor.util.SourceLevel;
-
-import com.google.auto.service.AutoService;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Processor for the &#64;{@link FreeBuilder} annotation.
@@ -78,10 +76,7 @@ public class Processor extends AbstractProcessor {
       try {
         Metadata metadata = analyser.analyse(type);
         CompilationUnitWriter code = new CompilationUnitWriter(
-            processingEnv.getFiler(),
-            processingEnv.getElementUtils(),
-            SourceLevel.from(processingEnv.getSourceVersion()),
-            isGuavaAvailable(),
+            processingEnv,
             metadata.getGeneratedBuilder().getQualifiedName(),
             metadata.getVisibleNestedTypes(),
             type);
@@ -107,11 +102,5 @@ public class Processor extends AbstractProcessor {
       }
     }
     return false;
-  }
-
-  private boolean isGuavaAvailable() {
-    String name = Shading.unshadedName(ImmutableList.class.getName());
-    TypeElement element = processingEnv.getElementUtils().getTypeElement(name);
-    return (element != null);
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
@@ -19,6 +19,8 @@ import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -90,7 +92,7 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
           LinkedHashSet.class,
           elementType,
           property.getName(),
-          code.getSourceLevel().supportsDiamondOperator() ? "" : elementType);
+          code.feature(SOURCE_LEVEL).supportsDiamondOperator() ? "" : elementType);
     }
 
     @Override
@@ -234,7 +236,7 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
     @Override
     public void addFinalFieldAssignment(SourceBuilder code, String finalField, String builder) {
       code.add("%s = ", finalField);
-      if (code.isGuavaAvailable()) {
+      if (code.feature(GUAVA).isAvailable()) {
         code.add("%s.copyOf", ImmutableSet.class);
       } else {
         code.add("immutableSet");
@@ -289,7 +291,7 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
     IMMUTABLE_SET {
       @Override
       public void addTo(SourceBuilder code) {
-        if (!code.isGuavaAvailable()) {
+        if (!code.feature(GUAVA).isAvailable()) {
           code.addLine("")
               .addLine("private static <E> %1$s<E> immutableSet(%1$s<E> elements) {",
                   Set.class, Class.class)
@@ -300,7 +302,7 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
               .addLine("    return %s.singleton(elements.iterator().next());", Collections.class)
               .addLine("  default:")
               .add("    return %s.unmodifiableSet(new %s<", Collections.class, LinkedHashSet.class);
-          if (!code.getSourceLevel().supportsDiamondOperator()) {
+          if (!code.feature(SOURCE_LEVEL).supportsDiamondOperator()) {
             code.add("E");
           }
           code.add(">(elements));\n")

--- a/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
@@ -17,7 +17,15 @@ package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.transform;
+
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
+
 import static java.util.Collections.nCopies;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 
 import java.util.List;
 
@@ -27,9 +35,6 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleElementVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
-
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
 
 public class ParameterizedType extends ValueType implements Excerpt {
 
@@ -87,7 +92,7 @@ public class ParameterizedType extends ValueType implements Excerpt {
   public Excerpt constructor() {
     return new Excerpt() {
       @Override public void addTo(SourceBuilder source) {
-        if (isParameterized() && source.getSourceLevel().supportsDiamondOperator()) {
+        if (isParameterized() && source.feature(SOURCE_LEVEL).supportsDiamondOperator()) {
           source.add("new %s<>", qualifiedName);
         } else {
           source.add("new %s", ParameterizedType.this);
@@ -149,8 +154,8 @@ public class ParameterizedType extends ValueType implements Excerpt {
 
   @Override
   public String toString() {
-    // Only used when debugging, so using J6/Guava is fine.
-    return new SourceStringBuilder(SourceLevel.JAVA_6, true, new TypeShortener.NeverShorten())
+    // Only used when debugging, so an empty feature set is fine.
+    return new SourceStringBuilder(new TypeShortener.NeverShorten(), new StaticFeatureSet())
         .add(this)
         .toString();
   }

--- a/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
@@ -1,5 +1,8 @@
 package org.inferred.freebuilder.processor.util;
 
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
+
 import com.google.common.base.Preconditions;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
@@ -46,9 +49,9 @@ public class PreconditionExcerpts {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        if (code.isGuavaAvailable()) {
+        if (code.feature(GUAVA).isAvailable()) {
           // No preamble needed
-        } else if (code.getSourceLevel().javaUtilObjects().isPresent()) {
+        } else if (code.feature(SOURCE_LEVEL).javaUtilObjects().isPresent()) {
           // No preamble needed
         } else {
           code.addLine("if (%s == null) {", reference)
@@ -80,11 +83,11 @@ public class PreconditionExcerpts {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        if (code.isGuavaAvailable()) {
+        if (code.feature(GUAVA).isAvailable()) {
           code.add("%s.checkNotNull(%s)", Preconditions.class, reference);
-        } else if (code.getSourceLevel().javaUtilObjects().isPresent()) {
+        } else if (code.feature(SOURCE_LEVEL).javaUtilObjects().isPresent()) {
           code.add("%s.requireNonNull(%s)",
-              code.getSourceLevel().javaUtilObjects().get(), reference);
+              code.feature(SOURCE_LEVEL).javaUtilObjects().get(), reference);
         } else {
           code.add("%s", reference);
         }
@@ -110,11 +113,11 @@ public class PreconditionExcerpts {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        if (code.isGuavaAvailable()) {
+        if (code.feature(GUAVA).isAvailable()) {
           code.addLine("%s.checkNotNull(%s);", Preconditions.class, reference);
-        } else if (code.getSourceLevel().javaUtilObjects().isPresent()) {
+        } else if (code.feature(SOURCE_LEVEL).javaUtilObjects().isPresent()) {
           code.addLine("%s.requireNonNull(%s);",
-              code.getSourceLevel().javaUtilObjects().get(), reference);
+              code.feature(SOURCE_LEVEL).javaUtilObjects().get(), reference);
         } else {
           code.addLine("if (%s == null) {", reference)
               .addLine("  throw new NullPointerException();")
@@ -177,7 +180,7 @@ public class PreconditionExcerpts {
     return new Excerpt() {
       @Override
       public void addTo(SourceBuilder code) {
-        if (code.isGuavaAvailable()) {
+        if (code.feature(GUAVA).isAvailable()) {
           code.add("%s.%s(%s, \"%s\"",
               Preconditions.class,
               methodName,

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
@@ -15,6 +15,11 @@
  */
 package org.inferred.freebuilder.processor.util;
 
+import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.inferred.freebuilder.processor.util.feature.FeatureType;
+import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
+
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -69,8 +74,17 @@ public interface SourceBuilder {
    */
   SourceStringBuilder subBuilder();
 
-  SourceLevel getSourceLevel();
-
-  boolean isGuavaAvailable();
+  /**
+   * Returns the instance of {@code featureType} appropriate for the source being written. For
+   * instance, <code>code.feature({@link GuavaLibrary#GUAVA
+   * GUAVA}).{@link GuavaLibrary#isAvailable() isAvailable()}</code> returns true if the Guava
+   * library can be used in the generated source code.
+   *
+   * <p>Fluent extension point for features dynamically determined based on the current
+   * {@link ProcessingEnvironment}.
+   *
+   * @see Feature
+   */
+  <T extends Feature<T>> T feature(FeatureType<T> featureType);
 
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
@@ -19,6 +19,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import static org.inferred.freebuilder.processor.util.AnnotationSource.addSource;
 
+import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.feature.FeatureType;
+import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -33,27 +38,21 @@ import javax.lang.model.type.TypeMirror;
  */
 public final class SourceStringBuilder implements SourceBuilder {
 
-  private final SourceLevel sourceLevel;
-  private final boolean guavaAvailable;
   private final TypeShortener shortener;
   private final StringBuilder destination = new StringBuilder();
+  private final FeatureSet features;
 
   /**
    * Returns a {@link SourceStringBuilder} that always shortens types, even if that causes
    * conflicts.
    */
-  public static SourceBuilder simple(SourceLevel sourceLevel, boolean isGuavaAvailable) {
-    return new SourceStringBuilder(
-        sourceLevel, isGuavaAvailable, new TypeShortener.AlwaysShorten());
+  public static SourceBuilder simple(Feature<?>... features) {
+    return new SourceStringBuilder(new TypeShortener.AlwaysShorten(), new StaticFeatureSet(features));
   }
 
-  SourceStringBuilder(
-      SourceLevel sourceLevel,
-      boolean isGuavaAvailable,
-      TypeShortener shortener) {
-    this.sourceLevel = sourceLevel;
-    this.guavaAvailable = isGuavaAvailable;
+  SourceStringBuilder(TypeShortener shortener, FeatureSet features) {
     this.shortener = shortener;
+    this.features = features;
   }
 
   @Override
@@ -79,17 +78,12 @@ public final class SourceStringBuilder implements SourceBuilder {
 
   @Override
   public SourceStringBuilder subBuilder() {
-    return new SourceStringBuilder(sourceLevel, guavaAvailable, shortener);
+    return new SourceStringBuilder(shortener, features);
   }
 
   @Override
-  public SourceLevel getSourceLevel() {
-    return sourceLevel;
-  }
-
-  @Override
-  public boolean isGuavaAvailable() {
-    return guavaAvailable;
+  public <T extends Feature<T>> T feature(FeatureType<T> feature) {
+    return features.get(feature);
   }
 
   /** Returns the source code written so far. */

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/EnvironmentFeatureSet.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/EnvironmentFeatureSet.java
@@ -1,0 +1,45 @@
+package org.inferred.freebuilder.processor.util.feature;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import javax.annotation.processing.ProcessingEnvironment;
+
+/**
+ * A set of {@link Feature} instances, determined dynamically by calling
+ * {@link FeatureType#forEnvironment(ProcessingEnvironment)}.
+ */
+public class EnvironmentFeatureSet implements FeatureSet {
+
+  private static class FeatureFromEnvironmentLoader
+      extends CacheLoader<FeatureType<?>, Feature<?>> {
+    private final ProcessingEnvironment env;
+
+    /** <pre>featureType -> featureType.forEnvironment(env)</pre> */
+    private FeatureFromEnvironmentLoader(ProcessingEnvironment env) {
+      this.env = env;
+    }
+
+    @Override
+    public Feature<?> load(FeatureType<?> featureType) {
+      return featureType.forEnvironment(env);
+    }
+  }
+
+  private final LoadingCache<FeatureType<?>, Feature<?>> featuresByType;
+
+  /** Constructs a feature set using the given processing environment. */
+  public EnvironmentFeatureSet(ProcessingEnvironment env) {
+    featuresByType = CacheBuilder.newBuilder()
+        .concurrencyLevel(1)
+        .build(new FeatureFromEnvironmentLoader(env));
+  }
+
+  @Override
+  public <T extends Feature<T>> T get(FeatureType<T> featureType) {
+    @SuppressWarnings("unchecked")
+    T feature = (T) featuresByType.getUnchecked(featureType);
+    return feature;
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/Feature.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/Feature.java
@@ -1,0 +1,17 @@
+package org.inferred.freebuilder.processor.util.feature;
+
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+/**
+ * A feature encapsulates the availability of a type or source level feature that can be used in
+ * the source written to a {@link SourceBuilder}, such as Java language-level features, or Guava
+ * types and methods.
+ *
+ * <p>A feature will typically provide a {@link FeatureType} constant that can be passed to
+ * {@code SourceBuilder#feature(FeatureType)} to determine the current status of a feature.
+ * For instance, to determine whether the diamond operator is available for use:
+ *
+ * <pre>code.feature({@link SourceLevel#SOURCE_LEVEL
+ *     SOURCE_LEVEL}).{@link SourceLevel#supportsDiamondOperator() supportsDiamondOperator()}</pre>
+ */
+public interface Feature<T extends Feature<T>> {}

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/FeatureSet.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/FeatureSet.java
@@ -1,0 +1,9 @@
+package org.inferred.freebuilder.processor.util.feature;
+
+/**
+ * A set of {@link Feature} instances, indexed by {@link FeatureType}.
+ */
+public interface FeatureSet {
+  /** Returns an instance of {@code featureType}. */
+  <T extends Feature<T>> T get(FeatureType<T> featureType);
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/FeatureType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/FeatureType.java
@@ -1,0 +1,26 @@
+package org.inferred.freebuilder.processor.util.feature;
+
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import javax.annotation.processing.ProcessingEnvironment;
+
+/**
+ * Algorithm to select the correct instance of a given feature type for a processing environment,
+ * and the default to use in tests when an explicit value has not been registered for that feature.
+ *
+ * <p>Each feature class should expose a single {@code FeatureType} constant for the user to pass
+ * to {@link SourceBuilder#feature(FeatureType)}, e.g. {@link SourceLevel#SOURCE_LEVEL}.
+ */
+public abstract class FeatureType<F extends Feature<F>> {
+
+  /** Returns the instance of {@code F} to use by default in tests. */
+  protected abstract F testDefault();
+
+  /** Returns the instance of {@code F} to use in {@code env}. */
+  protected abstract F forEnvironment(ProcessingEnvironment env);
+
+  @SuppressWarnings("unchecked")
+  protected Class<F> type() {
+    return (Class<F>) testDefault().getClass();
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/GuavaLibrary.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/GuavaLibrary.java
@@ -1,0 +1,40 @@
+package org.inferred.freebuilder.processor.util.feature;
+
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.util.Shading;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Whether the Guava library is available or not. Defaults to {@link #UNAVAILABLE} in tests.
+ */
+public enum GuavaLibrary implements Feature<GuavaLibrary> {
+
+  AVAILABLE, UNAVAILABLE;
+
+  /**
+   * Constant to pass to {@link SourceBuilder#feature(FeatureType)} to get the current status of
+   * {@link GuavaLibrary}.
+   */
+  public static final FeatureType<GuavaLibrary> GUAVA = new FeatureType<GuavaLibrary>() {
+
+    @Override
+    protected GuavaLibrary testDefault() {
+      return UNAVAILABLE;
+    }
+
+    @Override
+    protected GuavaLibrary forEnvironment(ProcessingEnvironment env) {
+      String name = Shading.unshadedName(ImmutableList.class.getName());
+      TypeElement element = env.getElementUtils().getTypeElement(name);
+      return (element != null) ? AVAILABLE : UNAVAILABLE;
+    }
+  };
+
+  public boolean isAvailable() {
+    return this != UNAVAILABLE;
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.inferred.freebuilder.processor.util;
-
-import javax.lang.model.SourceVersion;
+package org.inferred.freebuilder.processor.util.feature;
 
 import com.google.common.base.Optional;
+
+import org.inferred.freebuilder.processor.util.QualifiedName;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.SourceVersion;
 
 /**
  * Compliance levels which are idiomatically supported by this processor.
@@ -27,17 +31,31 @@ import com.google.common.base.Optional;
  * Additionally, {@code sourceLevel.supportsDiamondOperator()} is far more readable than
  * {@code sourceVersion.compareTo(SourceLevel.RELEASE_7) >= 0}.
  */
-public enum SourceLevel {
+public enum SourceLevel implements Feature<SourceLevel> {
+
   JAVA_6, JAVA_7;
 
-  public static SourceLevel from(SourceVersion sourceVersion) {
-    // RELEASE_6 is always available, as previous releases did not support annotation processing.
-    if (sourceVersion.compareTo(SourceVersion.RELEASE_6) <= 0) {
+  /**
+   * Constant to pass to {@link SourceBuilder#feature(FeatureType)} to get the current
+   * {@link SourceLevel}.
+   */
+  public static final FeatureType<SourceLevel> SOURCE_LEVEL = new FeatureType<SourceLevel>() {
+
+    @Override
+    protected SourceLevel testDefault() {
       return JAVA_6;
-    } else {
-      return JAVA_7;
     }
-  }
+
+    @Override
+    protected SourceLevel forEnvironment(ProcessingEnvironment env) {
+      // RELEASE_6 is always available, as previous releases did not support annotation processing.
+      if (env.getSourceVersion().compareTo(SourceVersion.RELEASE_6) <= 0) {
+        return JAVA_6;
+      } else {
+        return JAVA_7;
+      }
+    }
+  };
 
   public Optional<QualifiedName> javaUtilObjects() {
     switch (this) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/StaticFeatureSet.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/StaticFeatureSet.java
@@ -1,0 +1,41 @@
+package org.inferred.freebuilder.processor.util.feature;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Stores a set of {@link Feature} instances, defaulting to {@link FeatureType#testDefault()} when
+ * asked for a type that was not explicitly registered.
+ */
+public class StaticFeatureSet implements FeatureSet {
+
+  @SuppressWarnings("rawtypes")
+  private final ImmutableMap<Class<? extends Feature>, Feature<?>> featuresByType;
+
+  /**
+   * Creates a feature set which will return {@code features} when {@link #get} is called for the
+   * appropriate type.
+   */
+  public StaticFeatureSet(Feature<?>... features) {
+    @SuppressWarnings("rawtypes")
+    ImmutableMap.Builder<Class<? extends Feature>, Feature<?>> featuresBuilder =
+        ImmutableMap.builder();
+    for (Feature<?> feature : features) {
+      featuresBuilder.put(feature.getClass(), feature);
+    }
+    this.featuresByType = featuresBuilder.build();
+  }
+
+  /**
+   * Returns the registered instance of {@code featureType}, or the value of
+   * {@link FeatureType#testDefault()} if no explicit instance was registered with this set.
+   */
+  @Override
+  public <T extends Feature<T>> T get(FeatureType<T> featureType) {
+    @SuppressWarnings("unchecked")
+    T feature = (T) featuresByType.get(featureType.type());
+    if (feature != null) {
+      return feature;
+    }
+    return featureType.testDefault();
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -24,7 +24,6 @@ import static org.inferred.freebuilder.processor.BuilderFactory.NEW_BUILDER_METH
 import static org.inferred.freebuilder.processor.BuilderFactory.NO_ARGS_CONSTRUCTOR;
 import static org.inferred.freebuilder.processor.Metadata.Visibility.PACKAGE;
 import static org.inferred.freebuilder.processor.Metadata.Visibility.PRIVATE;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -1403,7 +1402,7 @@ public class AnalyserTest {
   }
 
   private static String asSource(Excerpt annotation) {
-    return SourceStringBuilder.simple(JAVA_6, true).add(annotation).toString().trim();
+    return SourceStringBuilder.simple().add(annotation).toString().trim();
   }
 
   private static final Function<Property, String> GET_NAME = new Function<Property, String>() {

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultSourceTest.java
@@ -20,9 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.TypeVariableImpl.newTypeVariable;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -35,9 +34,10 @@ import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.OptionalPropertyFactory.OptionalType;
 import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.ClassTypeImpl.ClassElementImpl;
+import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.SourceLevel;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,7 +53,7 @@ public class DefaultSourceTest {
   public void testRequiredProperties_j6() {
     Metadata metadata = createMetadataWithRequiredProperties();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -304,7 +304,7 @@ public class DefaultSourceTest {
   public void testNoRequiredProperties_j6() {
     Metadata metadata = createMetadataWithDefaults();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -496,7 +496,7 @@ public class DefaultSourceTest {
   public void testOptionalProperties_j6() {
     Metadata metadata = createMetadataWithOptionalProperties();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -787,7 +787,7 @@ public class DefaultSourceTest {
   public void testNullableProperties_j6() {
     Metadata metadata = createMetadataWithNullableProperties();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -991,7 +991,7 @@ public class DefaultSourceTest {
   public void testGenericType_j6() {
     Metadata metadata = createMetadataWithGenerics();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -1243,7 +1243,8 @@ public class DefaultSourceTest {
   public void testRequiredProperties_j7() {
     Metadata metadata = createMetadataWithRequiredProperties();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -1484,7 +1485,8 @@ public class DefaultSourceTest {
   public void testNoRequiredProperties_j7() {
     Metadata metadata = createMetadataWithDefaults();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -1664,7 +1666,8 @@ public class DefaultSourceTest {
   public void testOptionalProperties_j7() {
     Metadata metadata = createMetadataWithOptionalProperties();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -1943,7 +1946,8 @@ public class DefaultSourceTest {
   public void testNullableProperties_j7() {
     Metadata metadata = createMetadataWithNullableProperties();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -2135,7 +2139,8 @@ public class DefaultSourceTest {
   public void testGenericType_j7() {
     Metadata metadata = createMetadataWithGenerics();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -2377,7 +2382,7 @@ public class DefaultSourceTest {
   public void testRequiredProperties_noGuava_j6() {
     Metadata metadata = createMetadataWithRequiredProperties();
 
-    assertThat(generateSource(metadata, JAVA_6, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -2636,7 +2641,7 @@ public class DefaultSourceTest {
   public void testRequiredProperties_noGuava_j7() {
     Metadata metadata = createMetadataWithRequiredProperties();
 
-    assertThat(generateSource(metadata, JAVA_7, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, JAVA_7)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -2883,7 +2888,7 @@ public class DefaultSourceTest {
   public void testNoRequiredProperties_noGuava_j6() {
     Metadata metadata = createMetadataWithDefaults();
 
-    assertThat(generateSource(metadata, JAVA_6, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -3131,7 +3136,7 @@ public class DefaultSourceTest {
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
 
-    assertThat(generateSource(metadata, JAVA_6, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -3429,9 +3434,8 @@ public class DefaultSourceTest {
         "}\n"));
   }
 
-  private static String generateSource(
-      Metadata metadata, SourceLevel sourceLevel, boolean isGuavaAvailable) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(sourceLevel, isGuavaAvailable);
+  private static String generateSource(Metadata metadata, Feature<?>... features) {
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
     new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());

--- a/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
@@ -25,8 +25,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.SourceLevel;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.testing.FakeMessager;
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
@@ -133,8 +131,6 @@ public class JacksonSupportTest {
   }
 
   private static String asString(Excerpt excerpt) {
-    SourceBuilder code = SourceStringBuilder.simple(SourceLevel.JAVA_6, true);
-    code.add(excerpt);
-    return code.toString();
+    return SourceStringBuilder.simple().add(excerpt).toString();
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -20,8 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -33,8 +32,9 @@ import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.SourceLevel;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
+import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -48,7 +48,7 @@ public class ListSourceTest {
   public void test_guava_j6() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -329,7 +329,8 @@ public class ListSourceTest {
   public void test_guava_j7() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -598,7 +599,7 @@ public class ListSourceTest {
   public void test_noGuava_j6() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_6, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -897,7 +898,7 @@ public class ListSourceTest {
   public void test_noGuava_j7() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_7, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, JAVA_7)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -1177,9 +1178,8 @@ public class ListSourceTest {
         "}\n"));
   }
 
-  private static String generateSource(
-      Metadata metadata, SourceLevel sourceLevel, boolean isGuavaAvailable) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(sourceLevel, isGuavaAvailable);
+  private static String generateSource(Metadata metadata, Feature<?>... features) {
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
     new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -20,8 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -33,8 +32,9 @@ import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.SourceLevel;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
+import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -48,7 +48,7 @@ public class MapSourceTest {
   public void test_guava_j6() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -246,7 +246,8 @@ public class MapSourceTest {
   public void test_guava_j7() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -437,7 +438,7 @@ public class MapSourceTest {
   public void test_noGuava_j6() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_6, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -650,7 +651,7 @@ public class MapSourceTest {
   public void test_noGuava_j7() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_7, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, JAVA_7)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -850,9 +851,8 @@ public class MapSourceTest {
         "}\n"));
   }
 
-  private static String generateSource(
-      Metadata metadata, SourceLevel sourceLevel, boolean isGuavaAvailable) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(sourceLevel, isGuavaAvailable);
+  private static String generateSource(Metadata metadata, Feature<?>... features) {
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
     new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -19,8 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -32,8 +31,9 @@ import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.SourceLevel;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
+import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -47,7 +47,7 @@ public class SetSourceTest {
   public void test_guava_j6() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_6, true)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, GuavaLibrary.AVAILABLE)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -252,7 +252,8 @@ public class SetSourceTest {
   public void test_guava_j7() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_7, true)).isEqualTo(Joiner.on('\n').join(
+    String source = generateSource(metadata, JAVA_7, GuavaLibrary.AVAILABLE);
+    assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -451,7 +452,7 @@ public class SetSourceTest {
   public void test_noGuava_j6() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_6, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -672,7 +673,7 @@ public class SetSourceTest {
   public void test_noGuava_j7() {
     Metadata metadata = createMetadata();
 
-    assertThat(generateSource(metadata, JAVA_7, false)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadata, JAVA_7)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -877,9 +878,8 @@ public class SetSourceTest {
         "}\n"));
   }
 
-  private static String generateSource(
-      Metadata metadata, SourceLevel sourceLevel, boolean isGuavaAvailable) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(sourceLevel, isGuavaAvailable);
+  private static String generateSource(Metadata metadata, Feature<?>... features) {
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
     new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());

--- a/src/test/java/org/inferred/freebuilder/processor/util/CompilationUnitWriterTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/CompilationUnitWriterTest.java
@@ -17,25 +17,17 @@ package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static javax.lang.model.util.ElementFilter.fieldsIn;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.concurrent.atomic.AtomicLong;
+import static javax.lang.model.util.ElementFilter.fieldsIn;
 
-import javax.annotation.processing.Filer;
-import javax.annotation.processing.FilerException;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
-import javax.tools.JavaFileObject;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
 import org.junit.Before;
@@ -50,8 +42,19 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.FilerException;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.tools.JavaFileObject;
 
 /** Tests for {@link CompilationUnitWriter}. */
 @RunWith(MockitoJUnitRunner.class)
@@ -251,11 +254,10 @@ public class CompilationUnitWriterTest {
 
   private CompilationUnitWriter newSourceWriter(String pkg, String simpleName)
       throws FilerException {
+    ProcessingEnvironment environment = Mockito.spy(model.environment());
+    doReturn(filer).when(environment).getFiler();
     return new CompilationUnitWriter(
-        filer,
-        model.elementUtils(),
-        JAVA_6,
-        true,
+        environment,
         QualifiedName.of(pkg, simpleName),
         ImmutableSet.<QualifiedName>of(),
         originatingElement);

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElementTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElementTest.java
@@ -16,11 +16,12 @@
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeVariable;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
 import com.google.common.base.Function;
 
@@ -45,8 +46,7 @@ public class GenericElementTest {
         new GenericElement.Builder(FOO_BAR_NAME).build();
     assertThat(foobar.getSimpleName().toString()).isEqualTo("FooBar");
     assertThat(foobar.getTypeParameters()).isEmpty();
-    assertThat(SourceStringBuilder.simple(JAVA_7, true).add("%s", foobar).toString())
-        .isEqualTo("FooBar");
+    assertThat(SourceStringBuilder.simple().add("%s", foobar).toString()).isEqualTo("FooBar");
   }
 
   @Test
@@ -93,7 +93,7 @@ public class GenericElementTest {
       @Override public Void apply(DeclaredType foobar) {
         assertThat(foobar.asElement().getSimpleName().toString()).isEqualTo("FooBar");
         assertThat(foobar.getTypeArguments()).hasSize(2);
-        assertThat(SourceStringBuilder.simple(JAVA_7, true).add("%s", foobar).toString())
+        assertThat(SourceStringBuilder.simple(JAVA_7).add("%s", foobar).toString())
             .isEqualTo("FooBar<T, C>");
         return null;
       }
@@ -115,7 +115,7 @@ public class GenericElementTest {
       @Override public Void apply(DeclaredType foobar) {
         assertThat(foobar.asElement().getSimpleName().toString()).isEqualTo("FooBar");
         assertThat(foobar.getTypeArguments()).hasSize(2);
-        assertThat(SourceStringBuilder.simple(JAVA_7, true).add("%s", foobar).toString())
+        assertThat(SourceStringBuilder.simple(JAVA_7).add("%s", foobar).toString())
             .isEqualTo("FooBar<T, C>");
         return null;
       }
@@ -139,7 +139,7 @@ public class GenericElementTest {
         TypeElement foobarElement = maybeAsTypeElement(foobar).get();
         assertThat(foobarElement.getSimpleName().toString()).isEqualTo("FooBar");
         assertThat(foobar.getTypeArguments()).hasSize(1);
-        assertThat(SourceStringBuilder.simple(JAVA_7, true).add("%s", foobar).toString())
+        assertThat(SourceStringBuilder.simple(JAVA_7).add("%s", foobar).toString())
             .isEqualTo("FooBar<E>");
         // E extends FooBar<E>
         TypeParameterElement typeParameter = foobarElement.getTypeParameters().get(0);

--- a/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
@@ -18,6 +18,7 @@ package org.inferred.freebuilder.processor.util;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.junit.Assert.*;
 
+import org.inferred.freebuilder.processor.util.feature.SourceLevel;
 import org.junit.Test;
 
 public class ParameterizedTypeTest {
@@ -73,7 +74,7 @@ public class ParameterizedTypeTest {
   }
 
   private static String prettyPrint(Excerpt type, SourceLevel sourceLevel) {
-    return SourceStringBuilder.simple(sourceLevel, true).add(type).toString();
+    return SourceStringBuilder.simple(sourceLevel).add(type).toString();
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/PreconditionExcerptsTests.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/PreconditionExcerptsTests.java
@@ -1,9 +1,9 @@
 package org.inferred.freebuilder.processor.util;
 
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.junit.Assert.assertEquals;
 
+import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -13,7 +13,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckNotNull_guava() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkNotNull("foo"))
         .toString();
     assertEquals("Preconditions.checkNotNull(foo);\n", source);
@@ -21,7 +21,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckNotNull_j6() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkNotNull("foo"))
         .toString();
     assertEquals("if (foo == null) {\n  throw new NullPointerException();\n}\n", source);
@@ -29,7 +29,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckNotNull_j7() {
-    String source = SourceStringBuilder.simple(JAVA_7, false)
+    String source = SourceStringBuilder.simple(JAVA_7)
         .add(PreconditionExcerpts.checkNotNull("foo"))
         .toString();
     assertEquals("Objects.requireNonNull(foo);\n", source);
@@ -37,7 +37,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckNotNullInline_guava() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkNotNullPreamble("foo"))
         .addLine("this.foo = %s;", PreconditionExcerpts.checkNotNullInline("foo"))
         .toString();
@@ -46,7 +46,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckNotNullInline_j6() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkNotNullPreamble("foo"))
         .addLine("this.foo = %s;", PreconditionExcerpts.checkNotNullInline("foo"))
         .toString();
@@ -56,7 +56,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckNotNullInline_j7() {
-    String source = SourceStringBuilder.simple(JAVA_7, false)
+    String source = SourceStringBuilder.simple(JAVA_7)
         .add(PreconditionExcerpts.checkNotNullPreamble("foo"))
         .addLine("this.foo = %s;", PreconditionExcerpts.checkNotNullInline("foo"))
         .toString();
@@ -65,7 +65,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_guava_simpleMessage() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkArgument("foo != 0", "foo must not be zero"))
         .toString();
     assertEquals("Preconditions.checkArgument(foo != 0, \"foo must not be zero\");\n", source);
@@ -73,7 +73,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_guava_singleParameter() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkArgument("foo > 0", "foo must be positive, but got %s", "foo"))
         .toString();
     assertEquals("Preconditions.checkArgument(foo > 0, "
@@ -82,7 +82,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_guava_twoParameters() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkArgument(
             "foo > bar", "foo must be greater than bar, but got %s <= %s", "foo", "bar"))
         .toString();
@@ -92,7 +92,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_guava_doubleNegative() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkArgument("!foo.isEmpty()", "foo must not be empty"))
         .toString();
     assertEquals("Preconditions.checkArgument(!foo.isEmpty(), \"foo must not be empty\");\n", source);
@@ -100,7 +100,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_guava_doubleQuotes() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\\"\")", "foo must contain at least one double quote ('\"')"))
         .toString();
@@ -110,7 +110,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_guava_backslashes() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\\")", "foo must contain at least one backslash ('\\')"))
         .toString();
@@ -120,7 +120,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_guava_newLines() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkArgument(
             "foo.length() <= 80", "foo should not be more than 80 characters, but got:\n%s", "foo"))
         .toString();
@@ -130,7 +130,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_simpleMessage() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "message"))
         .toString();
     assertEquals(
@@ -139,7 +139,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_singleParameterAtEnd() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "message about %s", "foo"))
         .toString();
     assertEquals(
@@ -149,7 +149,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_singleParameterInMiddle() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "bar %s baz", "foo"))
         .toString();
     assertEquals(
@@ -159,7 +159,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_singleParameterAtStart() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "%s is wrong", "foo"))
         .toString();
     assertEquals(
@@ -169,7 +169,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_twoParametersInMiddle() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "a %s c %s e", "b", "d"))
         .toString();
     assertEquals(
@@ -180,7 +180,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_doubleQuotes() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\\"\")", "foo must contain at least one double quote ('\"')"))
         .toString();
@@ -192,7 +192,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_backslashes() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\\\\")", "foo must contain at least one backslash ('\\')"))
         .toString();
@@ -204,7 +204,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_newLines() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\n\")", "foo must contain at least one newline ('\n')"))
         .toString();
@@ -216,7 +216,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_doubleNegative() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("!foo.isEmpty()", "foo must not be empty"))
         .toString();
     assertEquals(
@@ -227,7 +227,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_complexCondition() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("a % 3 > 0", "message"))
         .toString();
     assertEquals(
@@ -236,7 +236,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_complexConditionWithMultipleBrackets() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("(a || b) && (c || d)", "message"))
         .toString();
     assertEquals(
@@ -246,7 +246,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckArgument_j6_instanceOf() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("a instanceof Integer", "message"))
         .toString();
     assertEquals(
@@ -256,7 +256,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckState_guava_simpleMessage() {
-    String source = SourceStringBuilder.simple(JAVA_6, true)
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
         .add(PreconditionExcerpts.checkState("foo != 0", "foo must not be zero"))
         .toString();
     assertEquals("Preconditions.checkState(foo != 0, \"foo must not be zero\");\n", source);
@@ -264,7 +264,7 @@ public class PreconditionExcerptsTests {
 
   @Test
   public void testCheckState_j6_simpleMessage() {
-    String source = SourceStringBuilder.simple(JAVA_6, false)
+    String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkState("foo != 0", "foo must not be zero"))
         .toString();
     assertEquals(

--- a/src/test/java/org/inferred/freebuilder/processor/util/SourceStringBuilderTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/SourceStringBuilderTest.java
@@ -17,12 +17,14 @@ package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static javax.lang.model.util.ElementFilter.fieldsIn;
-import static org.inferred.freebuilder.processor.util.SourceLevel.JAVA_6;
+
 import static org.junit.Assert.assertEquals;
+
+import static javax.lang.model.util.ElementFilter.fieldsIn;
 
 import com.google.common.collect.ImmutableList;
 
+import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,7 +48,7 @@ public class SourceStringBuilderTest {
   @Rule public final ModelRule model = new ModelRule();
   @Rule public final ExpectedException thrown = ExpectedException.none();
   private final ImportManager shortener = new ImportManager.Builder().build();
-  private final SourceBuilder builder = new SourceStringBuilder(JAVA_6, true, shortener);
+  private final SourceBuilder builder = new SourceStringBuilder(shortener, new StaticFeatureSet());
 
   @Test
   public void testConstructor() {

--- a/src/test/java/org/inferred/freebuilder/processor/util/feature/SourceLevelTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/feature/SourceLevelTest.java
@@ -13,23 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.inferred.freebuilder.processor.util;
+package org.inferred.freebuilder.processor.util.feature;
 
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 import static org.junit.Assert.assertEquals;
-
-import javax.lang.model.SourceVersion;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.SourceVersion;
+
 @RunWith(JUnit4.class)
 public class SourceLevelTest {
 
   @Test
-  public void testFrom() {
-    // Tests are currently run with JDK 7, so we can test up to RELEASE_7.
-    assertEquals(SourceLevel.JAVA_6, SourceLevel.from(SourceVersion.RELEASE_6));
-    assertEquals(SourceLevel.JAVA_7, SourceLevel.from(SourceVersion.RELEASE_7));
+  public void java6() {
+    assertEquals(SourceLevel.JAVA_6, sourceLevelFrom(SourceVersion.RELEASE_6));
+  }
+
+  @Test
+  public void java7() {
+    assertEquals(SourceLevel.JAVA_7, sourceLevelFrom(SourceVersion.RELEASE_7));
+  }
+
+  private static SourceLevel sourceLevelFrom(SourceVersion version) {
+    ProcessingEnvironment env = mock(ProcessingEnvironment.class);
+    when(env.getSourceVersion()).thenReturn(version);
+    return SOURCE_LEVEL.forEnvironment(env);
   }
 }


### PR DESCRIPTION
SourceBuilder can now be fluently extended with arbitrary features. When queried for a feature type, it will be determined based on the processing environment. Unit tests can instead provide a fixed feature set; SourceBuilder will then return either the exact feature it was constructed with, or the fallback for that feature type.

SourceLevel and Guava support are now implemented as features rather than being hard-coded into SourceBuilder.