### PR TITLE
Allow builder classes to be declared as abstract

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
@@ -66,7 +66,9 @@ public enum BuilderFactory {
   /** Determines the correct way of constructing a default {@code builderType} instance, if any. */
   public static Optional<BuilderFactory> from(TypeElement builderType) {
     ImmutableSet<String> staticMethods = findPotentialStaticFactoryMethods(builderType);
-    if (staticMethods.contains("builder")) {
+    if (typeIsAbstract(builderType)) {
+      return Optional.absent();
+    } else if (staticMethods.contains("builder")) {
       return Optional.of(BUILDER_METHOD);
     } else if (staticMethods.contains("newBuilder")) {
       return Optional.of(NEW_BUILDER_METHOD);
@@ -79,6 +81,10 @@ public enum BuilderFactory {
 
   /** Adds a code snippet calling the Builder factory method. */
   public abstract void addNewBuilder(SourceBuilder code, ParameterizedType builderType);
+
+  private static boolean typeIsAbstract(TypeElement type) {
+    return type.getModifiers().contains(Modifier.ABSTRACT);
+  }
 
   private static boolean hasExplicitNoArgsConstructor(TypeElement type) {
     for (ExecutableElement constructor : constructorsIn(type.getEnclosedElements())) {

--- a/src/test/java/org/inferred/freebuilder/processor/AbstractBuilderTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AbstractBuilderTest.java
@@ -1,0 +1,31 @@
+package org.inferred.freebuilder.processor;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
+import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+
+public class AbstractBuilderTest {
+    private final BehaviorTester behaviorTester = new BehaviorTester();
+
+    private static final JavaFileObject TYPE_WITH_ABSTRACT_BUILDER = new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public abstract class TypeWithAbstractBuilder {")
+            .addLine("  public abstract int getItem();")
+            .addLine("")
+            .addLine("  public abstract static class Builder extends TypeWithAbstractBuilder_Builder {}")
+            .addLine("}")
+            .build();
+
+    @Test
+    public void testGenericWithConstraint() {
+        behaviorTester
+                .with(new Processor())
+                .with(TYPE_WITH_ABSTRACT_BUILDER)
+                .compiles()
+                .withNoWarnings();
+    }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/BuilderFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuilderFactoryTest.java
@@ -47,6 +47,18 @@ public class BuilderFactoryTest {
   }
 
   @Test
+  public void testAbstractInnerClass() {
+    TypeElement builderType = (TypeElement) model.newElementWithMarker(
+        "package com.example;",
+        "class AbstractInnerClass {",
+        "  ---> abstract class Builder {}",
+        "}");
+
+    Optional<BuilderFactory> factory = BuilderFactory.from(builderType);
+    assertThat(factory).isAbsent();
+  }
+
+  @Test
   public void testExplicitNoArgsConstructor() {
     TypeElement builderType = (TypeElement) model.newElementWithMarker(
         "package com.example;",


### PR DESCRIPTION
It is useful if Builder classes can be declared as abstract, for then (for example) generic types can be discovered at runtime.

This commit ensures that no builder factory is registered for such a class. Current behaviour is to generate invalid Java, since such a class cannot be instantiated with its no-args constructor.