### PR TITLE
Clean up create methods

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
@@ -20,7 +20,9 @@ import static com.google.common.collect.Iterables.tryFind;
 
 import static org.inferred.freebuilder.processor.BuilderMethods.getBuilderMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.setter;
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
 import static org.inferred.freebuilder.processor.util.ModelUtils.findAnnotationMirror;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
 
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.util.ElementFilter.typesIn;
@@ -33,7 +35,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 
@@ -65,12 +66,11 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
 
   @Override
   public Optional<? extends PropertyCodeGenerator> create(Config config) {
-    // Check this is a declared type
-    TypeMirror type = config.getProperty().getType();
-    if (type.getKind() != TypeKind.DECLARED) {
+    DeclaredType type = maybeDeclared(config.getProperty().getType()).orNull();
+    if (type == null) {
       return Optional.absent();
     }
-    TypeElement element = (TypeElement) ((DeclaredType) type).asElement();
+    TypeElement element = asElement(type);
 
     // Find the builder
     Optional<TypeElement> builder =

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetPropertyFactory.java
@@ -23,9 +23,10 @@ import static org.inferred.freebuilder.processor.BuilderMethods.getter;
 import static org.inferred.freebuilder.processor.BuilderMethods.setCountMethod;
 import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeUnbox;
 
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.inferred.freebuilder.processor.Metadata.Property;
@@ -47,20 +48,14 @@ public class MultisetPropertyFactory implements PropertyCodeGenerator.Factory {
 
   @Override
   public Optional<CodeGenerator> create(Config config) {
-    if (config.getProperty().getType().getKind() == TypeKind.DECLARED) {
-      DeclaredType type = (DeclaredType) config.getProperty().getType();
-      if (erasesToAnyOf(type, Multiset.class, ImmutableMultiset.class)) {
-        TypeMirror elementType = upperBound(config.getElements(), type.getTypeArguments().get(0));
-        Optional<TypeMirror> unboxedType;
-        try {
-          unboxedType = Optional.<TypeMirror>of(config.getTypes().unboxedType(elementType));
-        } catch (IllegalArgumentException e) {
-          unboxedType = Optional.absent();
-        }
-        return Optional.of(new CodeGenerator(config.getProperty(), elementType, unboxedType));
-      }
+    DeclaredType type = maybeDeclared(config.getProperty().getType()).orNull();
+    if (type == null || !erasesToAnyOf(type, Multiset.class, ImmutableMultiset.class)) {
+      return Optional.absent();
     }
-    return Optional.absent();
+
+    TypeMirror elementType = upperBound(config.getElements(), type.getTypeArguments().get(0));
+    Optional<TypeMirror> unboxedType = maybeUnbox(elementType, config.getTypes());
+    return Optional.of(new CodeGenerator(config.getProperty(), elementType, unboxedType));
   }
 
   private static class CodeGenerator extends PropertyCodeGenerator {

--- a/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
@@ -23,14 +23,14 @@ import static org.inferred.freebuilder.processor.BuilderMethods.removeAllMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.removeMethod;
 import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeUnbox;
 
 import java.util.Collection;
 import java.util.Map.Entry;
 
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Types;
 
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
@@ -52,18 +52,17 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
 
   @Override
   public Optional<CodeGenerator> create(Config config) {
-    if (config.getProperty().getType().getKind() == TypeKind.DECLARED) {
-      DeclaredType type = (DeclaredType) config.getProperty().getType();
-      if (erasesToAnyOf(type, SetMultimap.class, ImmutableSetMultimap.class)) {
-        TypeMirror keyType = upperBound(config.getElements(), type.getTypeArguments().get(0));
-        TypeMirror valueType = upperBound(config.getElements(), type.getTypeArguments().get(1));
-        Optional<TypeMirror> unboxedKeyType = unboxed(config.getTypes(), keyType);
-        Optional<TypeMirror> unboxedValueType = unboxed(config.getTypes(), valueType);
-        return Optional.of(new CodeGenerator(
-            config.getProperty(), keyType, unboxedKeyType, valueType, unboxedValueType));
-      }
+    DeclaredType type = maybeDeclared(config.getProperty().getType()).orNull();
+    if (type == null || !erasesToAnyOf(type, SetMultimap.class, ImmutableSetMultimap.class)) {
+      return Optional.absent();
     }
-    return Optional.absent();
+
+    TypeMirror keyType = upperBound(config.getElements(), type.getTypeArguments().get(0));
+    TypeMirror valueType = upperBound(config.getElements(), type.getTypeArguments().get(1));
+    Optional<TypeMirror> unboxedKeyType = maybeUnbox(keyType, config.getTypes());
+    Optional<TypeMirror> unboxedValueType = maybeUnbox(valueType, config.getTypes());
+    return Optional.of(new CodeGenerator(
+        config.getProperty(), keyType, unboxedKeyType, valueType, unboxedValueType));
   }
 
   private static class CodeGenerator extends PropertyCodeGenerator {
@@ -331,15 +330,5 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
     public void addPartialClear(SourceBuilder code) {
       code.addLine("%s.clear();", property.getName());
     }
-  }
-
-  private static Optional<TypeMirror> unboxed(Types types, TypeMirror elementType) {
-    Optional<TypeMirror> unboxedType;
-    try {
-      unboxedType = Optional.<TypeMirror>of(types.unboxedType(elementType));
-    } catch (IllegalArgumentException e) {
-      unboxedType = Optional.absent();
-    }
-    return unboxedType;
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
@@ -15,6 +15,8 @@
  */
 package org.inferred.freebuilder.processor.util;
 
+import com.google.common.base.Optional;
+
 import java.lang.annotation.Annotation;
 import java.util.Map.Entry;
 
@@ -28,8 +30,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.SimpleElementVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
-
-import com.google.common.base.Optional;
+import javax.lang.model.util.Types;
 
 /**
  * Utility methods for the javax.lang.model package.
@@ -107,6 +108,15 @@ public class ModelUtils {
   /** Returns the {@link TypeElement} corresponding to {@code type}. */
   public static TypeElement asElement(DeclaredType type) {
     return maybeType(type.asElement()).get();
+  }
+
+  /** Applies unboxing conversion to {@code mirror}, if it can be unboxed. */
+  public static Optional<TypeMirror> maybeUnbox(TypeMirror mirror, Types types) {
+    try {
+      return Optional.<TypeMirror>of(types.unboxedType(mirror));
+    } catch (IllegalArgumentException e) {
+      return Optional.absent();
+    }
   }
 
   private static final SimpleElementVisitor6<Optional<TypeElement>, ?> TYPE_ELEMENT_VISITOR =


### PR DESCRIPTION
Refactor implementations of `PropertyCodeGenerator.Factory.create(Config)`:

 * use ModelUtils.maybeDeclared throughout
 * pull out common ModelUtils.maybeUnbox type
 * use immediate returns rather than nested if blocks