### PR TITLE
Add mutate for List properties

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
@@ -19,12 +19,15 @@ import static org.inferred.freebuilder.processor.BuilderMethods.addAllMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.addMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.clearMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.getter;
+import static org.inferred.freebuilder.processor.BuilderMethods.mutator;
 import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeUnbox;
+import static org.inferred.freebuilder.processor.util.ModelUtils.overrides;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
 import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
@@ -35,7 +38,10 @@ import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
+import org.inferred.freebuilder.processor.excerpt.CheckedList;
 import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import java.lang.reflect.Array;
@@ -64,17 +70,39 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
 
     TypeMirror elementType = upperBound(config.getElements(), type.getTypeArguments().get(0));
     Optional<TypeMirror> unboxedType = maybeUnbox(elementType, config.getTypes());
-    return Optional.of(new CodeGenerator(config.getProperty(), elementType, unboxedType));
+    boolean overridesAddMethod = hasAddMethodOverride(config, unboxedType.or(elementType));
+    return Optional.of(new CodeGenerator(
+        config.getProperty(),
+        overridesAddMethod,
+        elementType,
+        unboxedType));
+  }
+
+  private static boolean hasAddMethodOverride(Config config, TypeMirror keyType) {
+    return overrides(
+        config.getBuilder(),
+        config.getTypes(),
+        addMethod(config.getProperty()),
+        keyType);
   }
 
   @VisibleForTesting static class CodeGenerator extends PropertyCodeGenerator {
 
+    private static final ParameterizedType COLLECTION =
+        QualifiedName.of(Collection.class).withParameters("E");
+
+    private final boolean overridesAddMethod;
     private final TypeMirror elementType;
     private final Optional<TypeMirror> unboxedType;
 
     @VisibleForTesting
-    CodeGenerator(Property property, TypeMirror elementType, Optional<TypeMirror> unboxedType) {
+    CodeGenerator(
+        Property property,
+        boolean overridesAddMethod,
+        TypeMirror elementType,
+        Optional<TypeMirror> unboxedType) {
       super(property);
+      this.overridesAddMethod = overridesAddMethod;
       this.elementType = elementType;
       this.unboxedType = unboxedType;
     }
@@ -93,6 +121,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
       addAdd(code, metadata);
       addVarargsAdd(code, metadata);
       addAddAll(code, metadata);
+      addMutate(code, metadata);
       addClear(code, metadata);
       addGetter(code, metadata);
     }
@@ -109,9 +138,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
       }
       code.addLine(" */")
           .addLine("public %s %s(%s element) {",
-              metadata.getBuilder(),
-              addMethod(property),
-              unboxedType.or(elementType));
+              metadata.getBuilder(), addMethod(property), unboxedType.or(elementType));
       if (unboxedType.isPresent()) {
         code.addLine("  this.%s.add(element);", property.getName());
       } else {
@@ -170,6 +197,42 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine("    %s(element);", addMethod(property))
           .addLine("  }")
           .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
+    private void addMutate(SourceBuilder code, Metadata metadata) {
+      ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
+      if (consumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Applies {@code mutator} to the list to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" *")
+          .addLine(" * <p>This method mutates the list in-place. {@code mutator} is a void")
+          .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
+          .addLine(" * not to call pure functions, like %s.",
+              COLLECTION.javadocNoArgMethodLink("stream"))
+          .addLine(" *")
+          .addLine(" * @return this {@code Builder} object")
+          .addLine(" * @throws NullPointerException if {@code mutator} is null")
+          .addLine(" */")
+          .addLine("public %s %s(%s<? super %s<%s>> mutator) {",
+              metadata.getBuilder(),
+              mutator(property),
+              consumer.getQualifiedName(),
+              List.class,
+              elementType);
+      if (overridesAddMethod) {
+        code.addLine("  mutator.accept(new CheckedList<>(%s, this::%s));",
+            property.getName(), addMethod(property));
+      } else {
+        code.addLine("  // If %s is overridden, this method will be updated to delegate to it",
+                addMethod(property))
+            .addLine("  mutator.accept(%s);", property.getName());
+      }
+      code.addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");
     }
 
@@ -245,12 +308,17 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public Set<StaticMethod> getStaticMethods() {
-      return ImmutableSet.copyOf(StaticMethod.values());
+    public Set<Excerpt> getStaticMethods() {
+      ImmutableSet.Builder<Excerpt> methods = ImmutableSet.builder();
+      methods.add(StaticMethod.values());
+      if (overridesAddMethod) {
+        methods.addAll(CheckedList.excerpts());
+      }
+      return methods.build();
     }
   }
 
-  private static enum StaticMethod implements Excerpt {
+  private enum StaticMethod implements Excerpt {
     IMMUTABLE_LIST() {
       @Override
       public void addTo(SourceBuilder code) {

--- a/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedList.java
+++ b/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedList.java
@@ -1,0 +1,86 @@
+package org.inferred.freebuilder.processor.excerpt;
+
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
+
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import java.util.AbstractList;
+import java.util.List;
+import java.util.RandomAccess;
+
+/**
+ * Excerpts defining a list implementation that delegates to a provided add method to perform
+ * element validation and insertion into a random-access backing list.
+ */
+public class CheckedList {
+
+  public static List<Excerpt> excerpts() {
+    return ImmutableList.<Excerpt>of(CHECKED_LIST);
+  }
+
+  private static final Excerpt CHECKED_LIST = new Excerpt() {
+    @Override
+    public void addTo(SourceBuilder code) {
+      ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
+      if (consumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * A list implementation that delegates to a provided add method to perform")
+          .addLine(" * element validation and insertion into a random-access backing list.")
+          .addLine(" */")
+          .addLine("private static class CheckedList<E> extends %s<E> implements %s {",
+              AbstractList.class, RandomAccess.class)
+          .addLine("")
+          .addLine("  private final %s<E> list;", List.class)
+          .addLine("  private final %s<E> add;", consumer.getQualifiedName())
+          .addLine("")
+          .addLine("  CheckedList(%s<E> list, %s<E> add) {",
+              List.class, consumer.getQualifiedName())
+          .addLine("    this.list = list;")
+          .addLine("    this.add = add;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public int size() {")
+          .addLine("    return list.size();")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public E get(int index) {")
+          .addLine("    return list.get(index);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public E set(int index, E element) {")
+          .addLine("    add.accept(element);")
+          .addLine("    return list.set(index, list.remove(list.size() - 1));")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public void add(int index, E element) {")
+          .addLine("    int endIndex = list.size();")
+          .addLine("    add.accept(element);")
+          .addLine("    if (index != endIndex) {")
+          .addLine("      list.add(index, list.remove(endIndex));")
+          .addLine("    }")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public E remove(int index) {")
+          .addLine("    return list.remove(index);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public void clear() {")
+          .addLine("    list.clear();")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override protected void removeRange(int fromIndex, int toIndex) {")
+          .addLine("    list.subList(fromIndex, toIndex).clear();")
+          .addLine("  }")
+          .addLine("}");
+    }
+  };
+
+  private CheckedList() {}
+}

--- a/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor;
+
+import com.google.common.base.Preconditions;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
+import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+
+import javax.tools.JavaFileObject;
+
+@RunWith(JUnit4.class)
+public class ListMutateMethodTest {
+
+  private static final JavaFileObject UNCHECKED_LIST_TYPE = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public interface DataType {")
+      .addLine("  %s<Integer> getProperties();", List.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {}")
+      .addLine("}")
+      .build();
+
+  private static final JavaFileObject CHECKED_LIST_TYPE = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public interface DataType {")
+      .addLine("  %s<Integer> getProperties();", List.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {")
+      .addLine("    @Override public Builder addProperties(int element) {")
+      .addLine("      %s.checkArgument(element >= 0, \"elements must be non-negative\");",
+          Preconditions.class)
+      .addLine("      return super.addProperties(element);")
+      .addLine("    }")
+      .addLine("  }")
+      .addLine("}")
+      .build();
+
+  /** Simple type that substitutes passed-in objects, in this case by interning strings. */
+  private static final JavaFileObject INTERNED_STRINGS_TYPE = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public interface DataType {")
+      .addLine("  %s<String> getProperties();", List.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {")
+      .addLine("    @Override public Builder addProperties(String element) {")
+      .addLine("      return super.addProperties(element.intern());")
+      .addLine("    }")
+      .addLine("  }")
+      .addLine("}")
+      .build();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private final BehaviorTester behaviorTester = new BehaviorTester();
+
+  @Test
+  public void mutateAndAddModifiesUnderlyingPropertyWhenUnchecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(UNCHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .mutateProperties(map -> map.add(11))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(11);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddModifiesUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .mutateProperties(map -> map.add(11))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(11);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("elements must be non-negative");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder().mutateProperties(map -> map.add(-3));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_STRINGS_TYPE)
+        .with(new TestBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .mutateProperties(map -> map.add(s))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties().get(0)).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndex0ModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.add(0, 11))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(11, 1, 2, 3);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndex1ModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.add(1, 11))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(1, 11, 2, 3);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndex2ModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.add(2, 11))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(1, 2, 11, 3);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndex3ModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.add(3, 11))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(1, 2, 3, 11);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndexChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("elements must be non-negative");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.add(2, -3));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndexKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_STRINGS_TYPE)
+        .with(new TestBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(\"one\", \"two\", \"three\")")
+            .addLine("    .mutateProperties(map -> map.add(2, s))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties().get(2)).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndSetModifiesUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.set(1, 11))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(1, 11, 3).inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndSetChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("elements must be non-negative");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.set(1, -3));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndSetAtIndexKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_STRINGS_TYPE)
+        .with(new TestBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(\"one\", \"two\", \"three\")")
+            .addLine("    .mutateProperties(map -> map.set(2, s))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties().get(2)).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndSizeReadsFromUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> assertThat(map.size()).isEqualTo(3));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndGetReadsFromUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> assertThat(map.get(1)).isEqualTo(2));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndRemoveModifiesUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.remove(1))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(1, 3).inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndClearModifiesUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3)")
+            .addLine("    .mutateProperties(map -> map.clear())")
+            .addLine("    .addProperties(4)")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(4);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndClearSubListModifiesUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_LIST_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .addProperties(1, 2, 3, 4, 5, 6, 7)")
+            .addLine("    .mutateProperties(map -> map.subList(1, 5).clear())")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).containsExactly(1, 6, 7).inOrder();")
+            .build())
+        .runTest();
+  }
+
+}

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -1189,8 +1189,8 @@ public class ListSourceTest {
   }
 
   /**
-   * Returns a {@link Metadata} instance for a FreeBuilder type with a single property, name, of
-   * type {@code List<String>}.
+   * Returns a {@link Metadata} instance for a FreeBuilder type with two properties: name, of
+   * type {@code List<String>}; and age, of type {@code List<Integer>}.
    */
   private static Metadata createMetadata() {
     GenericTypeElementImpl list = newTopLevelGenericType("java.util.List");
@@ -1225,11 +1225,11 @@ public class ListSourceTest {
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
         .addProperties(name
             .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
-                name.build(), string, Optional.<TypeMirror>absent()))
+                name.build(), false, string, Optional.<TypeMirror>absent()))
             .build())
         .addProperties(age
             .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
-                age.build(), integer, Optional.<TypeMirror>of(INT)))
+                age.build(), false, integer, Optional.<TypeMirror>of(INT)))
             .build())
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())


### PR DESCRIPTION
CheckedList is a list implementation that delegates to a provided add method (in this case, the user's overridden addFoo method) to perform element validation and insertion into a random-access backing list.

This PR is part of issue #6.