### PR TITLE
Add mutate for Map properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ A <code>[Map][]</code> property called 'albums' would generate:
 | `putAlbums(int key, String value)` | Associates `key` with `value` in albums.  Throws a NullPointerException if either parameter is null. Replaces any existing entry. |
 | `putAllAlbums(Map<? extends Integer, ? extends String> map)` | Associates all of `map`'s keys and values in albums. Throws a NullPointerException if the map is null or contains a null key or value. Throws an IllegalArgumentException if any key is already present. |
 | `removeAlbums(int key)` | Removes the mapping for `key` from albums. Throws a NullPointerException if the parameter is null. Does nothing if the key is not present. |
+| `mutateAlbums(​Consumer<Map<Integer, String>> mutator)` | *Java 8+* Invokes the [Consumer] `mutator` with the map of albums. Throws a NullPointerException if `mutator` is null. As `mutator` is a void consumer, any value returned from a lambda will be igroned, so be careful not to call pure functions like [stream] expecting the returned map to replace the existing map. |
 | `clearAlbums()` | Removes all mappings from albums, leaving it empty. |
 | `getAlbums()` | Returns an unmodifiable view of the map of albums. Changes to the map held by the builder will be reflected in this view. |
 

--- a/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedMap.java
+++ b/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedMap.java
@@ -1,0 +1,207 @@
+package org.inferred.freebuilder.processor.excerpt;
+
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Excerpts defining a map implementation that delegates to a provided put method to perform entry
+ * validation and insertion into a backing map.
+ */
+public class CheckedMap {
+
+  public static final Set<Excerpt> excerpts() {
+    return ImmutableSet.of(CHECKED_ENTRY, CHECKED_ENTRY_ITERATOR, CHECKED_ENTRY_SET, CHECKED_MAP);
+  }
+
+  private static final Excerpt CHECKED_ENTRY = new Excerpt() {
+    @Override
+    public void addTo(SourceBuilder code) {
+      ParameterizedType biConsumer = code.feature(FUNCTION_PACKAGE).biConsumer().orNull();
+      if (biConsumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("private static class CheckedEntry<K, V> implements %s<K, V> {",
+              Map.Entry.class)
+          .addLine("")
+          .addLine("  private final %s<K, V> entry;", Map.Entry.class)
+          .addLine("  private final %s<K, V> put;", biConsumer.getQualifiedName())
+          .addLine("")
+          .addLine("  CheckedEntry(%s<K, V> entry, %s<K, V> put) {",
+              Map.Entry.class, biConsumer.getQualifiedName())
+          .addLine("    this.entry = entry;")
+          .addLine("    this.put = put;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public K getKey() {")
+          .addLine("    return entry.getKey();")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public V getValue() {")
+          .addLine("    return entry.getValue();")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public V setValue(V value) {")
+          .add(PreconditionExcerpts.checkNotNull("value"))
+          .addLine("    V oldValue = entry.getValue();")
+          .addLine("    put.accept(entry.getKey(), value);")
+          .addLine("    return oldValue;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean equals(Object o) {")
+          .addLine("    return entry.equals(o);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public int hashCode() {")
+          .addLine("    return entry.hashCode();")
+          .addLine("  }")
+          .addLine("}");
+    }
+  };
+
+  private static final Excerpt CHECKED_ENTRY_ITERATOR = new Excerpt() {
+    @Override
+    public void addTo(SourceBuilder code) {
+      ParameterizedType biConsumer = code.feature(FUNCTION_PACKAGE).biConsumer().orNull();
+      if (biConsumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("private static class CheckedEntryIterator<K, V> implements %s<%s<K, V>> {",
+              Iterator.class, Map.Entry.class)
+          .addLine("")
+          .addLine("  private final %s<%s<K, V>> iterator;", Iterator.class, Map.Entry.class)
+          .addLine("  private final %s<K, V> put;", biConsumer.getQualifiedName())
+          .addLine("")
+          .addLine("  CheckedEntryIterator(")
+          .addLine("      %s<%s<K, V>> iterator,", Iterator.class, Map.Entry.class)
+          .addLine("      %s<K, V> put) {", biConsumer.getQualifiedName())
+          .addLine("    this.iterator = iterator;")
+          .addLine("    this.put = put;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean hasNext() {")
+          .addLine("    return iterator.hasNext();")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public %s<K, V> next() {", Map.Entry.class)
+          .addLine("    return new CheckedEntry<K, V>(iterator.next(), put);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public void remove() {")
+          .addLine("    iterator.remove();")
+          .addLine("  }")
+          .addLine("}");
+    }
+  };
+
+  private static final Excerpt CHECKED_ENTRY_SET = new Excerpt() {
+    @Override
+    public void addTo(SourceBuilder code) {
+      ParameterizedType biConsumer = code.feature(FUNCTION_PACKAGE).biConsumer().orNull();
+      if (biConsumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("private static class CheckedEntrySet<K, V> extends %s<%s<K, V>> {",
+              AbstractSet.class, Map.Entry.class)
+          .addLine("")
+          .addLine("  private final %s<%s<K, V>> set;", Set.class, Map.Entry.class)
+          .addLine("  private final %s<K, V> put;", biConsumer.getQualifiedName())
+          .addLine("")
+          .addLine("  CheckedEntrySet(%s<%s<K, V>> set, %s<K, V> put) {",
+              Set.class, Map.Entry.class, biConsumer.getQualifiedName())
+          .addLine("    this.set = set;")
+          .addLine("    this.put = put;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public int size() {")
+          .addLine("    return set.size();")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public %s<%s<K, V>> iterator() {",
+              Iterator.class, Map.Entry.class)
+          .addLine("    return new CheckedEntryIterator<K, V>(set.iterator(), put);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean contains(Object o) {")
+          .addLine("    return set.contains(o);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean remove(Object o) {")
+          .addLine("    return set.remove(o);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public void clear() {")
+          .addLine("    set.clear();")
+          .addLine("  }")
+          .addLine("}");
+    }
+  };
+
+  private static final Excerpt CHECKED_MAP = new Excerpt() {
+    @Override
+    public void addTo(SourceBuilder code) {
+      ParameterizedType biConsumer = code.feature(FUNCTION_PACKAGE).biConsumer().orNull();
+      if (biConsumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * A map implementation that delegates to a provided put method")
+          .addLine(" * to perform entry validation and insertion into a backing map.")
+          .addLine(" */")
+          .addLine("private static class CheckedMap<K, V> extends %s<K, V> {",
+              AbstractMap.class)
+          .addLine("")
+          .addLine("  private final %s<K, V> map;", Map.class)
+          .addLine("  private final %s<K, V> put;", biConsumer.getQualifiedName())
+          .addLine("")
+          .addLine("  CheckedMap(%s<K, V> map, %s<K, V> put) {",
+              Map.class, biConsumer.getQualifiedName())
+          .addLine("    this.map = map;")
+          .addLine("    this.put = put;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public V get(Object key) {")
+          .addLine("    return map.get(key);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean containsKey(Object key) {")
+          .addLine("    return map.containsKey(key);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public V put(K key, V value) {")
+          .addLine("    V oldValue = map.get(key);")
+          .addLine("    put.accept(key, value);")
+          .addLine("    return oldValue;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public V remove(Object key) {")
+          .addLine("    return map.remove(key);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public void clear() {")
+          .addLine("    map.clear();")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public %s<%s<K, V>> entrySet() {",
+              Set.class, Map.Entry.class)
+          .addLine("    return new CheckedEntrySet<>(map.entrySet(), put);")
+          .addLine("  }")
+          .addLine("}");
+    }
+  };
+}

--- a/src/test/java/org/inferred/freebuilder/processor/MapMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapMutateMethodTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
+import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.tools.JavaFileObject;
+
+@RunWith(JUnit4.class)
+public class MapMutateMethodTest {
+
+  private static final JavaFileObject UNCHECKED_SET_TYPE = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public interface DataType {")
+      .addLine("  %s<Integer, String> getProperties();", Map.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {}")
+      .addLine("}")
+      .build();
+
+  private static final JavaFileObject CHECKED_SET_TYPE = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("import static %s.checkArgument;", Preconditions.class)
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public interface DataType {")
+      .addLine("  %s<Integer, String> getProperties();", Map.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {")
+      .addLine("    @Override public Builder putProperties(int key, String value) {")
+      .addLine("      checkArgument(key >= 0, \"key must be non-negative\");")
+      .addLine("      checkArgument(!value.startsWith(\"-\"), \"value must not start with '-'\");")
+      .addLine("      return super.putProperties(key, value);")
+      .addLine("    }")
+      .addLine("  }")
+      .addLine("}")
+      .build();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private final BehaviorTester behaviorTester = new BehaviorTester();
+
+  @Test
+  public void putModifiesUnderlyingPropertyWhenUnchecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(UNCHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .mutateProperties(map -> map.put(11, \"eleven\"))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).isEqualTo(%s.of(", ImmutableMap.class)
+            .addLine("    5, \"five\", 11, \"eleven\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void putChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("key must be non-negative");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .mutateProperties(map -> map.put(-1, \"minus one\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void putModifiesUnderlyingPropertyWhenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .mutateProperties(map -> map.put(11, \"eleven\"))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).isEqualTo(%s.of(", ImmutableMap.class)
+            .addLine("    5, \"five\", 11, \"eleven\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void iterateEntrySetFindsContainedEntry() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .mutateProperties(map -> {")
+            .addLine("      %s<Integer, String> entry = map.entrySet().iterator().next();",
+                Map.Entry.class)
+            .addLine("      assertThat(entry.getKey()).isEqualTo(5);")
+            .addLine("      assertThat(entry.getValue()).isEqualTo(\"five\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void callRemoveOnEntrySetIteratorModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .putProperties(6, \"six\")")
+            .addLine("    .mutateProperties(map -> {")
+            .addLine("        %s<%s<Integer, String>> i = map.entrySet().iterator();",
+                Iterator.class, Map.Entry.class)
+            .addLine("        i.next();")
+            .addLine("        i.remove();")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).isEqualTo(%s.of(", ImmutableMap.class)
+            .addLine("    6, \"six\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void entrySetIteratorRemainsUsableAfterCallingRemove() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .putProperties(6, \"six\")")
+            .addLine("    .mutateProperties(map -> {")
+            .addLine("        %s<%s<Integer, String>> i = map.entrySet().iterator();",
+                Iterator.class, Map.Entry.class)
+            .addLine("        %s<Integer, String> entry = i.next();", Map.Entry.class)
+            .addLine("        assertThat(entry.getKey()).isEqualTo(5);")
+            .addLine("        assertThat(entry.getValue()).isEqualTo(\"five\");")
+            .addLine("        assertThat(i.hasNext()).isTrue();")
+            .addLine("        i.remove();")
+            .addLine("        assertThat(i.hasNext()).isTrue();")
+            .addLine("        entry = i.next();", Map.Entry.class)
+            .addLine("        assertThat(entry.getKey()).isEqualTo(6);")
+            .addLine("        assertThat(entry.getValue()).isEqualTo(\"six\");")
+            .addLine("        assertThat(i.hasNext()).isFalse();")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void callSetValueOnEntryChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value must not start with '-'");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .mutateProperties(map ->")
+            .addLine("        map.entrySet().iterator().next().setValue(\"-five-\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void callSetValueOnEntryModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .mutateProperties(map ->")
+            .addLine("        map.entrySet().iterator().next().setValue(\"cinco\"))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).isEqualTo(%s.of(", ImmutableMap.class)
+            .addLine("    5, \"cinco\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void entryRemainsUsableAfterCallingSetValue() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .putProperties(6, \"six\")")
+            .addLine("    .mutateProperties(map -> {")
+            .addLine("        %s<%s<Integer, String>> i = map.entrySet().iterator();",
+                Iterator.class, Map.Entry.class)
+            .addLine("        %s<Integer, String> entry = i.next();", Map.Entry.class)
+            .addLine("        assertThat(entry.getKey()).isEqualTo(5);")
+            .addLine("        assertThat(entry.getValue()).isEqualTo(\"five\");")
+            .addLine("        entry.setValue(\"cinco\");")
+            .addLine("        assertThat(entry.getKey()).isEqualTo(5);")
+            .addLine("        assertThat(entry.getValue()).isEqualTo(\"cinco\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void entrySetIteratorRemainsUsableAfterCallingSetValue() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .putProperties(6, \"six\")")
+            .addLine("    .mutateProperties(map -> {")
+            .addLine("        %s<%s<Integer, String>> i = map.entrySet().iterator();",
+                Iterator.class, Map.Entry.class)
+            .addLine("        %s<Integer, String> entry = i.next();", Map.Entry.class)
+            .addLine("        assertThat(entry.getKey()).isEqualTo(5);")
+            .addLine("        assertThat(entry.getValue()).isEqualTo(\"five\");")
+            .addLine("        entry.setValue(\"cinco\");")
+            .addLine("        assertThat(i.hasNext()).isTrue();")
+            .addLine("        entry = i.next();", Map.Entry.class)
+            .addLine("        assertThat(entry.getKey()).isEqualTo(6);")
+            .addLine("        assertThat(entry.getValue()).isEqualTo(\"six\");")
+            .addLine("        assertThat(i.hasNext()).isFalse();")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void getReturnsContainedValue() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .mutateProperties(map -> assertThat(map.get(5)).isEqualTo(\"five\"))")
+            .addLine("    .mutateProperties(map -> assertThat(map.get(3)).isEqualTo(null));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void containsKeyFindsContainedKey() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .mutateProperties(map -> assertThat(map.containsKey(5)).isTrue())")
+            .addLine("    .mutateProperties(map -> assertThat(map.containsKey(3)).isFalse());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void removeModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .putProperties(6, \"six\")")
+            .addLine("    .mutateProperties(map -> map.remove(5))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).isEqualTo(%s.of(", ImmutableMap.class)
+            .addLine("    6, \"six\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void clearModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_SET_TYPE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .putProperties(5, \"five\")")
+            .addLine("    .putProperties(6, \"six\")")
+            .addLine("    .mutateProperties(%s::clear)", Map.class)
+            .addLine("    .build();")
+            .addLine("assertThat(value.getProperties()).isEmpty();")
+            .build())
+        .runTest();
+  }
+
+}

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -858,6 +858,7 @@ public class MapSourceTest {
         .addProperties(name
             .setCodeGenerator(new MapPropertyFactory.CodeGenerator(
                 name.build(),
+                false,
                 integer,
                 Optional.<TypeMirror>of(INT),
                 string,


### PR DESCRIPTION
CheckedMap is a map implementation that delegates to a provided put method (in this case, the user's overridden putFoo method) to perform entry validation and insertion into a backing map.

This PR is part of issue #6.