### PR TITLE
Add mutate for ListMultimap properties

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
@@ -17,6 +17,7 @@ package org.inferred.freebuilder.processor;
 
 import static org.inferred.freebuilder.processor.BuilderMethods.clearMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.getter;
+import static org.inferred.freebuilder.processor.BuilderMethods.mutator;
 import static org.inferred.freebuilder.processor.BuilderMethods.putAllMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.putMethod;
 import static org.inferred.freebuilder.processor.BuilderMethods.removeAllMethod;
@@ -25,21 +26,28 @@ import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeUnbox;
+import static org.inferred.freebuilder.processor.util.ModelUtils.overrides;
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
 
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
+import org.inferred.freebuilder.processor.excerpt.CheckedListMultimap;
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
@@ -69,12 +77,30 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
     TypeMirror valueType = upperBound(config.getElements(), type.getTypeArguments().get(1));
     Optional<TypeMirror> unboxedKeyType = maybeUnbox(keyType, config.getTypes());
     Optional<TypeMirror> unboxedValueType = maybeUnbox(valueType, config.getTypes());
+    boolean overridesPutMethod =
+        hasPutMethodOverride(config, unboxedKeyType.or(keyType), unboxedValueType.or(valueType));
     return Optional.of(new CodeGenerator(
-        config.getProperty(), keyType, unboxedKeyType, valueType, unboxedValueType));
+        config.getProperty(),
+        overridesPutMethod,
+        keyType,
+        unboxedKeyType,
+        valueType,
+        unboxedValueType));
+  }
+
+  private static boolean hasPutMethodOverride(
+      Config config, TypeMirror keyType, TypeMirror valueType) {
+    return overrides(
+        config.getBuilder(),
+        config.getTypes(),
+        putMethod(config.getProperty()),
+        keyType,
+        valueType);
   }
 
   private static class CodeGenerator extends PropertyCodeGenerator {
 
+    private final boolean overridesPutMethod;
     private final TypeMirror keyType;
     private final Optional<TypeMirror> unboxedKeyType;
     private final TypeMirror valueType;
@@ -82,11 +108,13 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
 
     CodeGenerator(
         Property property,
+        boolean overridesPutMethod,
         TypeMirror keyType,
         Optional<TypeMirror> unboxedKeyType,
         TypeMirror valueType,
         Optional<TypeMirror> unboxedValueType) {
       super(property);
+      this.overridesPutMethod = overridesPutMethod;
       this.keyType = keyType;
       this.unboxedKeyType = unboxedKeyType;
       this.valueType = valueType;
@@ -106,6 +134,7 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
       addMultimapPutAll(code, metadata);
       addRemove(code, metadata);
       addRemoveAll(code, metadata);
+      addMutate(code, metadata);
       addClear(code, metadata);
       addGetter(code, metadata);
     }
@@ -264,6 +293,41 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
           .addLine("}");
     }
 
+    private void addMutate(SourceBuilder code, Metadata metadata) {
+      ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
+      if (consumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Applies {@code mutator} to the multimap to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" *")
+          .addLine(" * <p>This method mutates the multimap in-place. {@code mutator} is a void")
+          .addLine(" * consumer, so any value returned from a lambda will be ignored.")
+          .addLine(" *")
+          .addLine(" * @return this {@code Builder} object")
+          .addLine(" * @throws NullPointerException if {@code mutator} is null")
+          .addLine(" */")
+          .addLine("public %s %s(%s<%s<%s, %s>> mutator) {",
+              metadata.getBuilder(),
+              mutator(property),
+              consumer.getQualifiedName(),
+              ListMultimap.class,
+              keyType,
+              valueType);
+      if (overridesPutMethod) {
+        code.addLine("  mutator.accept(new CheckedListMultimap<>(%s, this::%s));",
+            property.getName(), putMethod(property));
+      } else {
+        code.addLine("  // If %s is overridden, this method will be updated to delegate to it",
+                putMethod(property))
+            .addLine("  mutator.accept(%s);", property.getName());
+      }
+      code.addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
     private void addClear(SourceBuilder code, Metadata metadata) {
       code.addLine("")
           .addLine("/**")
@@ -333,6 +397,15 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
     @Override
     public void addPartialClear(SourceBuilder code) {
       code.addLine("%s.clear();", property.getName());
+    }
+
+    @Override
+    public Set<? extends Excerpt> getStaticMethods() {
+      ImmutableSet.Builder<Excerpt> staticMethods = ImmutableSet.builder();
+      if (overridesPutMethod) {
+        staticMethods.addAll(CheckedListMultimap.excerpts());
+      }
+      return staticMethods.build();
     }
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedListMultimap.java
+++ b/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedListMultimap.java
@@ -1,0 +1,114 @@
+package org.inferred.freebuilder.processor.excerpt;
+
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ForwardingListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+/**
+ * Excerpts defining a multimap implementation that delegates to a provided put method to perform
+ * entry validation and insertion into a backing multimap.
+ */
+public class CheckedListMultimap {
+
+  public static List<Excerpt> excerpts() {
+    return ImmutableList.<Excerpt>builder()
+        .addAll(CheckedList.excerpts())
+        .add(CHECKED_LIST_MULTIMAP)
+        .build();
+  }
+
+  private static final Excerpt CHECKED_LIST_MULTIMAP = new Excerpt() {
+    @Override
+    public void addTo(SourceBuilder code) {
+      ParameterizedType biConsumer = code.feature(FUNCTION_PACKAGE).biConsumer().orNull();
+      if (biConsumer == null) {
+        return;
+      }
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * A multimap implementation that delegates to a provided put method")
+          .addLine(" * to perform entry validation and insertion into a backing multimap.")
+          .addLine(" */")
+          .addLine("private static class CheckedListMultimap<K, V> extends %s<K, V> {",
+              ForwardingListMultimap.class)
+          .addLine("")
+          .addLine("  private final %s<K, V> multimap;", ListMultimap.class)
+          .addLine("  private final %s<K, V> put;", biConsumer.getQualifiedName())
+          .addLine("")
+          .addLine("  CheckedListMultimap(%s<K, V> multimap, %s<K, V> put) {",
+              ListMultimap.class, biConsumer.getQualifiedName())
+          .addLine("    this.multimap = multimap;")
+          .addLine("    this.put = put;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override protected %s<K, V> delegate() {", ListMultimap.class)
+          .addLine("    return multimap;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean put(@%1$s K key, @%1$s V value) {", Nullable.class)
+          .addLine("    put.accept(key, value);")
+          .addLine("    return true;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean putAll(@%s K key, %s<? extends V> values) {",
+              Nullable.class, Iterable.class)
+          .addLine("    boolean anyModified = false;")
+          .addLine("    for (V value : values) {")
+          .addLine("      put.accept(key, value);")
+          .addLine("      anyModified = true;")
+          .addLine("    }")
+          .addLine("    return anyModified;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public boolean putAll(%s<? extends K, ? extends V> multimap) {",
+              Multimap.class)
+          .addLine("    boolean changed = false;")
+          .addLine("    for (%s<? extends K, ? extends V> entry : multimap.entries()) {",
+              Map.Entry.class)
+          .addLine("      put.accept(entry.getKey(), entry.getValue());")
+          .addLine("      changed = true;")
+          .addLine("    }")
+          .addLine("    return changed;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override")
+          .addLine("  public %s<V> replaceValues(@%s K key, %s<? extends V> values) {",
+              List.class, Nullable.class, Iterable.class)
+          .addLine("    %s.checkNotNull(values);", Preconditions.class)
+          .addLine("    %s<V> result = removeAll(key);", List.class)
+          .addLine("    putAll(key, values);")
+          .addLine("    return result;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public %s<V> get(@%s K key) {", List.class, Nullable.class)
+          .addLine("    return new CheckedList<>(")
+          .addLine("        multimap.get(key), value -> put.accept(key, value));")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @Override public %s<K, %s<V>> asMap() {", Map.class, Collection.class)
+          .addLine("    return %s.transformEntries(%s.asMap(multimap), (key, values) -> ",
+              Maps.class, Multimaps.class)
+          .addLine("        new CheckedList<>(values, value -> put.accept(key, value)));")
+          .addLine("  }")
+          .addLine("}");
+    }
+  };
+
+  private CheckedListMultimap() {}
+}

--- a/src/test/java/org/inferred/freebuilder/processor/ListMultimapMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMultimapMutateMethodTest.java
@@ -1,0 +1,483 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimaps;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
+import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Iterator;
+
+import javax.tools.JavaFileObject;
+
+@RunWith(JUnit4.class)
+public class ListMultimapMutateMethodTest {
+
+  private static final JavaFileObject UNCHECKED_PROPERTY = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public abstract class DataType {")
+      .addLine("  public abstract %s<String, String> getItems();", ListMultimap.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {}")
+      .addLine("}")
+      .build();
+
+  private static final JavaFileObject CHECKED_PROPERTY = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public abstract class DataType {")
+      .addLine("  public abstract %s<String, String> getItems();", ListMultimap.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {")
+      .addLine("    @Override public Builder putItems(String key, String value) {")
+      .addLine("      %s.checkArgument(!key.isEmpty(), \"key may not be empty\");",
+          Preconditions.class)
+      .addLine("      %s.checkArgument(!value.isEmpty(), \"value may not be empty\");",
+          Preconditions.class)
+      .addLine("      return super.putItems(key, value);")
+      .addLine("    }")
+      .addLine("  }")
+      .addLine("}")
+      .build();
+
+  private static final JavaFileObject INTERNED_PROPERTY = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public abstract class DataType {")
+      .addLine("  public abstract %s<String, String> getItems();", ListMultimap.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {")
+      .addLine("    @Override public Builder putItems(String key, String value) {")
+      .addLine("      return super.putItems(key.intern(), value.intern());")
+      .addLine("    }")
+      .addLine("  }")
+      .addLine("}")
+      .build();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private final BehaviorTester behaviorTester = new BehaviorTester();
+
+  @Test
+  public void mutateAndPutModifiesUnderlyingProperty_whenUnchecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(UNCHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("      items.put(\"one\", \"A\");")
+            .addLine("      items.put(\"two\", \"B\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"B\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutModifiesUnderlyingProperty_whenChecked() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("      items.put(\"one\", \"A\");")
+            .addLine("      items.put(\"two\", \"B\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"B\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value may not be empty");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder().mutateItems(items -> items.put(\"one\", \"\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_PROPERTY)
+        .with(testBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> items.put(\"one\", s))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutAllValuesModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("      items.putAll(\"one\", ImmutableList.of(\"A\", \"a\"));")
+            .addLine("      items.putAll(\"two\", ImmutableList.of(\"B\", \"b\"));")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\", \"a\")")
+            .addLine("    .and(\"two\", \"B\", \"b\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutAllValuesChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value may not be empty");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder().mutateItems(items -> items")
+            .addLine("    .putAll(\"one\", ImmutableList.of(\"A\", \"\")));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutAllValuesKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_PROPERTY)
+        .with(testBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> items")
+            .addLine("        .putAll(\"one\", ImmutableList.of(s, \"bazbam\")))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutAllMultimapModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> items")
+            .addLine("        .putAll(ImmutableMultimap.of(\"one\", \"A\", \"two\", \"B\")))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\")")
+            .addLine("    .and(\"two\", \"B\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutAllMultimapChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value may not be empty");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder().mutateItems(items -> items")
+            .addLine("    .putAll(ImmutableMultimap.of(\"one\", \"A\", \"two\", \"\")));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndPutAllMultimapKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_PROPERTY)
+        .with(testBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> items")
+            .addLine("        .putAll(ImmutableMultimap.of(\"one\", s, \"two\", \"bazbam\")))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndReplaceValuesModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"i\")")
+            .addLine("    .mutateItems(items -> items")
+            .addLine("        .replaceValues(\"one\", ImmutableList.of(\"A\", \"a\")))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\", \"a\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndReplaceValuesChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value may not be empty");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"i\")")
+            .addLine("    .mutateItems(items -> items")
+            .addLine("        .replaceValues(\"one\", ImmutableList.of(\"A\", \"\")));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndReplaceValuesKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_PROPERTY)
+        .with(testBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"i\")")
+            .addLine("    .mutateItems(items -> items")
+            .addLine("        .replaceValues(\"one\", ImmutableList.of(s, \"a\")))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddViaGetModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .mutateItems(items -> items.get(\"one\").add(\"a\"))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\", \"a\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddViaGetChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value may not be empty");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .mutateItems(items -> items.get(\"one\").add(\"\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddViaGetKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_PROPERTY)
+        .with(testBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .mutateItems(items -> items.get(\"one\").add(s))")
+            .addLine("    .build();")
+            .addLine("Iterator<? extends String> it = value.getItems().values().iterator();")
+            .addLine("it.next();")
+            .addLine("assertThat(it.next()).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddViaAsMapModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .mutateItems(items -> items.asMap().get(\"one\").add(\"a\"))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\", \"a\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddViaAsMapChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value may not be empty");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .mutateItems(items -> items.asMap().get(\"one\").add(\"\"));")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddViaAsMapKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_PROPERTY)
+        .with(testBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putItems(\"one\", \"A\")")
+            .addLine("    .mutateItems(items -> items.asMap().get(\"one\").add(s))")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems().get(\"one\").get(1)).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndexViaAsMapModifiesUnderlyingProperty() {
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(\"one\", ImmutableList.of(\"A\", \"B\", \"C\"))")
+            .addLine("    .mutateItems(items -> %s.asMap(items).get(\"one\").add(2, \"foo\"))",
+                Multimaps.class)
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems())")
+            .addLine("    .contains(\"one\", \"A\", \"B\", \"foo\", \"C\")")
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndexViaAsMapChecksArguments() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value may not be empty");
+    behaviorTester
+        .with(new Processor())
+        .with(CHECKED_PROPERTY)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .putAllItems(\"one\", ImmutableList.of(\"A\", \"B\", \"C\"))")
+            .addLine("    .mutateItems(items -> %s.asMap(items).get(\"one\").add(2, \"\"));",
+                Multimaps.class)
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mutateAndAddAtIndexViaAsMapKeepsSubstitute() {
+    behaviorTester
+        .with(new Processor())
+        .with(INTERNED_PROPERTY)
+        .with(testBuilder()
+            .addLine("String s = new String(\"foobar\");")
+            .addLine("String i = s.intern();")
+            .addLine("assertThat(s).isNotSameAs(i);")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .putAllItems(\"one\", ImmutableList.of(\"A\", \"B\", \"C\"))")
+            .addLine("    .mutateItems(items -> %s.asMap(items).get(\"one\").add(2, s))",
+                Multimaps.class)
+            .addLine("    .build();")
+            .addLine("assertThat(value.getItems().get(\"one\").get(2)).isSameAs(i);")
+            .build())
+        .runTest();
+  }
+
+  private static TestBuilder testBuilder() {
+    return new TestBuilder()
+        .addStaticImport(MultimapSubject.class, "assertThat")
+        .addImport("com.example.DataType")
+        .addImport(ImmutableList.class)
+        .addImport(ImmutableMultimap.class)
+        .addImport(Iterator.class);
+  }
+
+}


### PR DESCRIPTION
CheckedListMultimap is a multimap implementation that delegates to a provided put method (in this case, the user's overridden putFoo method) to perform entry validation and insertion into a backing multimap.

This PR is part of issue #6.