### PR TITLE
Fix raw reference to Guava in OptionalPropertyFactory

### DIFF
--- a/src/it/no-guava-j8/invoker.properties
+++ b/src/it/no-guava-j8/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean test

--- a/src/it/no-guava-j8/pom.xml
+++ b/src/it/no-guava-j8/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2014 Google Inc. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.inferred.freebuilder.it</groupId>
+  <artifactId>no-guava-integration-tests</artifactId>
+  <version>TEST-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Integration tests (no Guava)</name>
+  <url>http://inferred.org/freebuilder/it/no-guava</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.inferred</groupId>
+      <artifactId>freebuilder</artifactId>
+      <version>@test.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/no-guava-j8/src/main/java/org/inferred/freebuilder/OptionalProperty.java
+++ b/src/it/no-guava-j8/src/main/java/org/inferred/freebuilder/OptionalProperty.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+@FreeBuilder
+public interface OptionalProperty extends Serializable {
+  Optional<String> getName();
+
+  public static class Builder extends OptionalProperty_Builder { }
+}

--- a/src/it/no-guava-j8/src/test/java/org/inferred/freebuilder/OptionalPropertyTest.java
+++ b/src/it/no-guava-j8/src/test/java/org/inferred/freebuilder/OptionalPropertyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Optional;
+
+/** FreeBuilder test using {@link ListProperty}. */
+@RunWith(JUnit4.class)
+public class OptionalPropertyTest {
+
+  private static final String NAME_1 = "name1";
+  private static final String NAME_2 = "name2";
+  private static final String NAME_3 = "name3";
+
+  @Test
+  public void testAllMethodInteractions() {
+    OptionalProperty.Builder builder = new OptionalProperty.Builder();
+    assertEquals(Optional.empty(), builder.build().getName());
+    builder.setName(NAME_1);
+    assertEquals(Optional.of(NAME_1), builder.build().getName());
+    builder.mapName(n -> n.substring(0,4) + "2");
+    assertEquals(Optional.of(NAME_2), builder.build().getName());
+    builder.clearName();
+    assertEquals(Optional.empty(), builder.build().getName());
+    builder.setName(NAME_3);
+    assertEquals(Optional.of(NAME_3), builder.build().getName());
+    builder.clear();
+    assertEquals(Optional.empty(), builder.build().getName());
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/OptionalPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/OptionalPropertyFactory.java
@@ -40,7 +40,6 @@ import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 
 /**
  * {@link PropertyCodeGenerator.Factory} providing a default value (absent) and convenience
@@ -194,8 +193,9 @@ public class OptionalPropertyFactory implements PropertyCodeGenerator.Factory {
       if (unboxedType.isPresent()) {
         code.addLine("  this.%1$s = %1$s;", property.getName());
       } else {
-        code.addLine("  this.%1$s = %2$s.checkNotNull(%1$s);",
-            property.getName(), Preconditions.class);
+        code.add(PreconditionExcerpts.checkNotNullPreamble(property.getName()))
+            .addLine("  this.%s = %s;",
+                property.getName(), PreconditionExcerpts.checkNotNullInline(property.getName()));
       }
       code.addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");


### PR DESCRIPTION
This was causing uncompilable code to be generated when using J8 Optional properties without Guava as a dependency. This fixes #153.