### PR TITLE
Pass Metadata to CodeGenerator factories

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
@@ -136,6 +136,7 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     return Optional.of(new CodeGenerator(
+        config.getMetadata(),
         config.getProperty(),
         ParameterizedType.from(builder.get()),
         builderFactory.get(),
@@ -149,11 +150,12 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
     final MergeBuilderMethod mergeFromBuilderMethod;
 
     CodeGenerator(
+        Metadata metadata,
         Property property,
         ParameterizedType builderType,
         BuilderFactory builderFactory,
         MergeBuilderMethod mergeFromBuilderMethod) {
-      super(property);
+      super(metadata, property);
       this.builderType = builderType;
       this.builderFactory = builderFactory;
       this.mergeFromBuilderMethod = mergeFromBuilderMethod;
@@ -166,7 +168,7 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addSetter(code, metadata);
       addSetterTakingBuilder(code, metadata);
       addMutate(code, metadata);
@@ -270,7 +272,7 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       String propertyName = property.getName();
       if (propertyName.equals(builder)) {
         propertyName = "this." + propertyName;  // see issue #78

--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -147,7 +147,7 @@ public class CodeGenerator {
 
   private static void addAccessors(Metadata metadata, SourceBuilder body) {
     for (Property property : metadata.getProperties()) {
-      property.getCodeGenerator().addBuilderFieldAccessors(body, metadata);
+      property.getCodeGenerator().addBuilderFieldAccessors(body);
     }
   }
 
@@ -208,10 +208,10 @@ public class CodeGenerator {
       if (property.getCodeGenerator().getType() == Type.REQUIRED) {
         code.addLine("  if (!_templateUnset.contains(%s.%s)) {",
             metadata.getPropertyEnum(), property.getAllCapsName());
-        property.getCodeGenerator().addMergeFromBuilder(code, metadata, "template");
+        property.getCodeGenerator().addMergeFromBuilder(code, "template");
         code.addLine("  }");
       } else {
-        property.getCodeGenerator().addMergeFromBuilder(code, metadata, "template");
+        property.getCodeGenerator().addMergeFromBuilder(code, "template");
       }
     }
     code.addLine("  return (%s) this;", metadata.getBuilder());

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
@@ -42,7 +42,7 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
   public Optional<? extends PropertyCodeGenerator> create(Config config) {
     Property property = config.getProperty();
     boolean hasDefault = config.getMethodsInvokedInBuilderConstructor().contains(setter(property));
-    return Optional.of(new CodeGenerator(property, hasDefault));
+    return Optional.of(new CodeGenerator(config.getMetadata(), property, hasDefault));
   }
 
   @VisibleForTesting static class CodeGenerator extends PropertyCodeGenerator {
@@ -50,8 +50,8 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
     private final boolean hasDefault;
     private final boolean isPrimitive;
 
-    CodeGenerator(Property property, boolean hasDefault) {
-      super(property);
+    CodeGenerator(Metadata metadata, Property property, boolean hasDefault) {
+      super(metadata, property);
       this.hasDefault = hasDefault;
       this.isPrimitive = property.getType().getKind().isPrimitive();
     }
@@ -67,7 +67,7 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, final Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addSetter(code, metadata);
       addMapper(code, metadata);
       addGetter(code, metadata);
@@ -176,7 +176,7 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(%s.%s());", setter(property), builder, getter(property));
     }
 

--- a/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactory.java
@@ -80,6 +80,7 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
     boolean overridesPutMethod =
         hasPutMethodOverride(config, unboxedKeyType.or(keyType), unboxedValueType.or(valueType));
     return Optional.of(new CodeGenerator(
+        config.getMetadata(),
         config.getProperty(),
         overridesPutMethod,
         keyType,
@@ -107,13 +108,14 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
     private final Optional<TypeMirror> unboxedValueType;
 
     CodeGenerator(
+        Metadata metadata,
         Property property,
         boolean overridesPutMethod,
         TypeMirror keyType,
         Optional<TypeMirror> unboxedKeyType,
         TypeMirror valueType,
         Optional<TypeMirror> unboxedValueType) {
-      super(property);
+      super(metadata, property);
       this.overridesPutMethod = overridesPutMethod;
       this.keyType = keyType;
       this.unboxedKeyType = unboxedKeyType;
@@ -128,7 +130,7 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addPut(code, metadata);
       addSingleKeyPutAll(code, metadata);
       addMultimapPutAll(code, metadata);
@@ -371,7 +373,7 @@ public class ListMultimapPropertyFactory implements PropertyCodeGenerator.Factor
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(((%s) %s).%s);",
           putAllMethod(property),
           metadata.getGeneratedBuilder(),

--- a/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
@@ -73,6 +73,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
     Optional<TypeMirror> unboxedType = maybeUnbox(elementType, config.getTypes());
     boolean overridesAddMethod = hasAddMethodOverride(config, unboxedType.or(elementType));
     return Optional.of(new CodeGenerator(
+        config.getMetadata(),
         config.getProperty(),
         overridesAddMethod,
         elementType,
@@ -98,11 +99,12 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
 
     @VisibleForTesting
     CodeGenerator(
+        Metadata metadata,
         Property property,
         boolean overridesAddMethod,
         TypeMirror elementType,
         Optional<TypeMirror> unboxedType) {
-      super(property);
+      super(metadata, property);
       this.overridesAddMethod = overridesAddMethod;
       this.elementType = elementType;
       this.unboxedType = unboxedType;
@@ -118,7 +120,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addAdd(code, metadata);
       addVarargsAdd(code, metadata);
       addAddAll(code, metadata);
@@ -280,7 +282,7 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(((%s) %s).%s);",
           addAllMethod(property),
           metadata.getGeneratedBuilder(),

--- a/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapPropertyFactory.java
@@ -73,6 +73,7 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
     boolean overridesPutMethod = hasPutMethodOverride(
         config, unboxedKeyType.or(keyType), unboxedValueType.or(valueType));
     return Optional.of(new CodeGenerator(
+        config.getMetadata(),
         config.getProperty(),
         overridesPutMethod,
         keyType,
@@ -104,13 +105,14 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
     private final Optional<TypeMirror> unboxedValueType;
 
     CodeGenerator(
+        Metadata metadata,
         Property property,
         boolean overridesPutMethod,
         TypeMirror keyType,
         Optional<TypeMirror> unboxedKeyType,
         TypeMirror valueType,
         Optional<TypeMirror> unboxedValueType) {
-      super(property);
+      super(metadata, property);
       this.overridesPutMethod = overridesPutMethod;
       this.keyType = keyType;
       this.unboxedKeyType = unboxedKeyType;
@@ -129,7 +131,7 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addPut(code, metadata);
       addPutAll(code, metadata);
       addRemove(code, metadata);
@@ -304,7 +306,7 @@ public class MapPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(((%s) %s).%s);",
           putAllMethod(property),
           metadata.getGeneratedBuilder(),

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata.java
@@ -141,39 +141,43 @@ public abstract class Metadata {
   /** Returns a list of nested classes that should be added to the generated builder class. */
   public abstract ImmutableList<Function<Metadata, Excerpt>> getNestedClasses();
 
+  public Builder toBuilder() {
+    return new Builder().mergeFrom(this);
+  }
+
   /** Metadata about a property of a {@link Metadata}. */
-  public interface Property {
+  public abstract static class Property {
 
     /** Returns the type of the property. */
-    TypeMirror getType();
+    public abstract TypeMirror getType();
 
     /** Returns the boxed form of {@link #getType()}, or null if type is not primitive. */
-    @Nullable TypeMirror getBoxedType();
+    @Nullable public abstract TypeMirror getBoxedType();
 
     /** Returns the name of the property, e.g. myProperty. */
-    String getName();
+    public abstract String getName();
 
     /** Returns the capitalized name of the property, e.g. MyProperty. */
-    String getCapitalizedName();
+    public abstract String getCapitalizedName();
 
     /** Returns the name of the property in all-caps with underscores, e.g. MY_PROPERTY. */
-    String getAllCapsName();
+    public abstract String getAllCapsName();
 
     /** Returns the name of the getter for the property, e.g. getMyProperty, or isSomethingTrue. */
-    String getGetterName();
+    public abstract String getGetterName();
 
     /**
      * Returns the code generator to use for this property, or null if no generator has been picked
      * (i.e. when passed to {@link PropertyCodeGenerator.Factory#create}.
      */
-    @Nullable PropertyCodeGenerator getCodeGenerator();
+    @Nullable public abstract PropertyCodeGenerator getCodeGenerator();
 
     /**
      * Returns true if a cast to this property type is guaranteed to be fully checked at runtime.
      * This is true for any type that is non-generic, raw, or parameterized with unbounded
      * wildcards, such as {@code Integer}, {@code List} or {@code Map<?, ?>}.
      */
-    boolean isFullyCheckedCast();
+    public abstract boolean isFullyCheckedCast();
 
     /**
      * Returns a list of annotations that should be applied to the accessor methods of this
@@ -181,10 +185,14 @@ public abstract class Metadata {
      * of the getter method as its argument. For a list, for example, that would be getX() and
      * addAllX().
      */
-    ImmutableList<Excerpt> getAccessorAnnotations();
+    public abstract ImmutableList<Excerpt> getAccessorAnnotations();
+
+    public Builder toBuilder() {
+      return new Builder().mergeFrom(this);
+    }
 
     /** Builder for {@link Property}. */
-    class Builder extends Metadata_Property_Builder {}
+    public static class Builder extends Metadata_Property_Builder {}
   }
 
   public static final Function<Property, PropertyCodeGenerator> GET_CODE_GENERATOR =

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata_Property_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata_Property_Builder.java
@@ -395,7 +395,7 @@ abstract class Metadata_Property_Builder {
     return new Metadata_Property_Builder.Partial(this);
   }
 
-  private static final class Value implements Metadata.Property {
+  private static final class Value extends Metadata.Property {
     private final TypeMirror type;
     @Nullable private final TypeMirror boxedType;
     private final String name;
@@ -536,7 +536,7 @@ abstract class Metadata_Property_Builder {
     }
   }
 
-  private static final class Partial implements Metadata.Property {
+  private static final class Partial extends Metadata.Property {
     private final TypeMirror type;
     @Nullable private final TypeMirror boxedType;
     private final String name;

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetPropertyFactory.java
@@ -70,7 +70,11 @@ public class MultisetPropertyFactory implements PropertyCodeGenerator.Factory {
     boolean overridesSetCountMethod =
         hasSetCountMethodOverride(config, unboxedType.or(elementType));
     return Optional.of(new CodeGenerator(
-        config.getProperty(), overridesSetCountMethod, elementType, unboxedType));
+        config.getMetadata(),
+        config.getProperty(),
+        overridesSetCountMethod,
+        elementType,
+        unboxedType));
   }
 
   private static boolean hasSetCountMethodOverride(
@@ -92,11 +96,12 @@ public class MultisetPropertyFactory implements PropertyCodeGenerator.Factory {
     private final Optional<TypeMirror> unboxedType;
 
     CodeGenerator(
+        Metadata metadata,
         Property property,
         boolean overridesSetCountMethod,
         TypeMirror elementType,
         Optional<TypeMirror> unboxedType) {
-      super(property);
+      super(metadata, property);
       this.overridesSetCountMethod = overridesSetCountMethod;
       this.elementType = elementType;
       this.unboxedType = unboxedType;
@@ -109,7 +114,7 @@ public class MultisetPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addAdd(code, metadata);
       addVarargsAdd(code, metadata);
       addAddAll(code, metadata);
@@ -310,7 +315,7 @@ public class MultisetPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(((%s) %s).%s);",
           addAllMethod(property),
           metadata.getGeneratedBuilder(),

--- a/src/main/java/org/inferred/freebuilder/processor/NullablePropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/NullablePropertyFactory.java
@@ -48,7 +48,7 @@ public class NullablePropertyFactory implements PropertyCodeGenerator.Factory {
     if (isPrimitive || nullableAnnotations.isEmpty()) {
       return Optional.absent();
     }
-    return Optional.of(new CodeGenerator(property, nullableAnnotations));
+    return Optional.of(new CodeGenerator(config.getMetadata(), property, nullableAnnotations));
   }
 
   private static Set<TypeElement> nullablesIn(Iterable<? extends AnnotationMirror> annotations) {
@@ -68,8 +68,8 @@ public class NullablePropertyFactory implements PropertyCodeGenerator.Factory {
 
     private final Set<TypeElement> nullables;
 
-    CodeGenerator(Property property, Iterable<TypeElement> nullableAnnotations) {
-      super(property);
+    CodeGenerator(Metadata metadata, Property property, Iterable<TypeElement> nullableAnnotations) {
+      super(metadata, property);
       this.nullables = ImmutableSet.copyOf(nullableAnnotations);
     }
 
@@ -85,7 +85,7 @@ public class NullablePropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, final Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addSetter(code, metadata);
       addMapper(code, metadata);
       addGetter(code, metadata);
@@ -166,7 +166,7 @@ public class NullablePropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(%s.%s());", setter(property), builder, getter(property));
     }
 

--- a/src/main/java/org/inferred/freebuilder/processor/OptionalPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/OptionalPropertyFactory.java
@@ -120,6 +120,7 @@ public class OptionalPropertyFactory implements PropertyCodeGenerator.Factory {
     boolean requiresExplicitTypeParameters = HAS_WILDCARD.visit(elementType);
 
     return Optional.of(new CodeGenerator(
+        config.getMetadata(),
         config.getProperty(),
         optionalType,
         elementType,
@@ -144,12 +145,13 @@ public class OptionalPropertyFactory implements PropertyCodeGenerator.Factory {
     private final boolean requiresExplicitTypeParameters;
 
     @VisibleForTesting CodeGenerator(
+        Metadata metadata,
         Property property,
         OptionalType optional,
         TypeMirror elementType,
         Optional<TypeMirror> unboxedType,
         boolean requiresExplicitTypeParametersInJava7) {
-      super(property);
+      super(metadata, property);
       this.optional = optional;
       this.elementType = elementType;
       this.unboxedType = unboxedType;
@@ -178,7 +180,7 @@ public class OptionalPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addSetter(code, metadata);
       addOptionalSetter(code, metadata);
       addNullableSetter(code, metadata);
@@ -325,7 +327,7 @@ public class OptionalPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       String propertyValue = builder + "." + getter(property) + "()";
       optional.invokeIfPresent(code, propertyValue, setter(property));
     }

--- a/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
@@ -43,6 +43,9 @@ public abstract class PropertyCodeGenerator {
 
   /** Data available to {@link Factory} instances when creating a {@link PropertyCodeGenerator}. */
   interface Config {
+    /** Returns metadata about the builder being generated. */
+    Metadata getMetadata();
+
     /** Returns metadata about the property requiring code generation. */
     Metadata.Property getProperty();
 
@@ -77,9 +80,11 @@ public abstract class PropertyCodeGenerator {
     Optional<? extends PropertyCodeGenerator> create(Config config);
   }
 
+  protected final Metadata metadata;
   protected final Property property;
 
-  public PropertyCodeGenerator(Property property) {
+  public PropertyCodeGenerator(Metadata metadata, Property property) {
+    this.metadata = metadata;
     this.property = property;
   }
 
@@ -100,7 +105,7 @@ public abstract class PropertyCodeGenerator {
   public abstract void addBuilderFieldDeclaration(SourceBuilder code);
 
   /** Add the accessor methods for the property to the builder's source code. */
-  public abstract void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata);
+  public abstract void addBuilderFieldAccessors(SourceBuilder code);
 
   /** Add the final assignment of the property to the value object's source code. */
   public abstract void addFinalFieldAssignment(
@@ -115,7 +120,7 @@ public abstract class PropertyCodeGenerator {
   public abstract void addMergeFromValue(SourceBuilder code, String value);
 
   /** Add a merge from builder for the property to the builder's source code. */
-  public abstract void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder);
+  public abstract void addMergeFromBuilder(SourceBuilder code, String builder);
 
   /** Adds method annotations for the value type getter method. */
   public void addGetterAnnotations(@SuppressWarnings("unused") SourceBuilder code) {}

--- a/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactory.java
@@ -72,6 +72,7 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
     boolean overridesPutMethod =
         hasPutMethodOverride(config, unboxedKeyType.or(keyType), unboxedValueType.or(valueType));
     return Optional.of(new CodeGenerator(
+        config.getMetadata(),
         config.getProperty(),
         overridesPutMethod,
         keyType,
@@ -99,12 +100,13 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
     private final Optional<TypeMirror> unboxedValueType;
 
     CodeGenerator(
+        Metadata metadata,
         Property property,
         boolean overridesPutMethod,
         TypeMirror keyType,
         Optional<TypeMirror> unboxedKeyType,
         TypeMirror valueType, Optional<TypeMirror> unboxedValueType) {
-      super(property);
+      super(metadata, property);
       this.overridesPutMethod = overridesPutMethod;
       this.keyType = keyType;
       this.unboxedKeyType = unboxedKeyType;
@@ -119,7 +121,7 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addPut(code, metadata);
       addSingleKeyPutAll(code, metadata);
       addMultimapPutAll(code, metadata);
@@ -367,7 +369,7 @@ public class SetMultimapPropertyFactory implements PropertyCodeGenerator.Factory
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(((%s) %s).%s);",
           putAllMethod(property),
           metadata.getGeneratedBuilder(),

--- a/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
@@ -70,7 +70,7 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
     Optional<TypeMirror> unboxedType = maybeUnbox(elementType, config.getTypes());
     boolean overridesAddMethod = hasAddMethodOverride(config, unboxedType.or(elementType));
     return Optional.of(new CodeGenerator(
-        config.getProperty(), elementType, unboxedType, overridesAddMethod));
+        config.getMetadata(), config.getProperty(), elementType, unboxedType, overridesAddMethod));
   }
 
   private static boolean hasAddMethodOverride(Config config, TypeMirror elementType) {
@@ -91,11 +91,12 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
     private final boolean overridesAddMethod;
 
     CodeGenerator(
+        Metadata metadata,
         Property property,
         TypeMirror elementType,
         Optional<TypeMirror> unboxedType,
         boolean overridesAddMethod) {
-      super(property);
+      super(metadata, property);
       this.elementType = elementType;
       this.unboxedType = unboxedType;
       this.overridesAddMethod = overridesAddMethod;
@@ -111,7 +112,7 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addBuilderFieldAccessors(SourceBuilder code, Metadata metadata) {
+    public void addBuilderFieldAccessors(SourceBuilder code) {
       addAdd(code, metadata);
       addVarargsAdd(code, metadata);
       addAddAll(code, metadata);
@@ -303,7 +304,7 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
     }
 
     @Override
-    public void addMergeFromBuilder(SourceBuilder code, Metadata metadata, String builder) {
+    public void addMergeFromBuilder(SourceBuilder code, String builder) {
       code.addLine("%s(((%s) %s).%s);",
           addAllMethod(property),
           metadata.getGeneratedBuilder(),

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultSourceTest.java
@@ -16,6 +16,7 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.TypeVariableImpl.newTypeVariable;
@@ -2175,30 +2176,33 @@ public class DefaultSourceTest {
     QualifiedName person = QualifiedName.of("com.example", "Person");
     TypeMirror string = newTopLevelClass("java.lang.String");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(string)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(string);
-    Property.Builder age = new Property.Builder()
+        .setType(string)
+        .build();
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setBoxedType(newTopLevelClass("java.lang.Integer"))
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(INT);
-    Property.Builder shoeSize = new Property.Builder()
+        .setType(INT)
+        .build();
+    Property shoeSize = new Property.Builder()
         .setAllCapsName("SHOE_SIZE")
         .setBoxedType(newTopLevelClass("java.lang.Integer"))
         .setCapitalizedName("ShoeSize")
         .setFullyCheckedCast(true)
         .setGetterName("getShoeSize")
         .setName("shoeSize")
-        .setType(INT);
+        .setType(INT)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -2206,24 +2210,25 @@ public class DefaultSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                name.build(), false))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                age.build(), true))
-            .build())
-        .addProperties(shoeSize
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                shoeSize.build(), false))
-            .build())
+        .addProperties(name, age, shoeSize)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
+    Metadata metadataWithCodeGenerators = metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, name, false))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, age, true))
+            .build())
+        .addProperties(shoeSize.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, shoeSize, false))
+            .build())
+        .build();
 
-    assertThat(generateSource(metadata)).isEqualTo(Joiner.on('\n').join(
+    assertThat(generateSource(metadataWithCodeGenerators)).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
@@ -3315,22 +3320,24 @@ public class DefaultSourceTest {
     QualifiedName person = QualifiedName.of("com.example", "Person");
     TypeMirror string = newTopLevelClass("java.lang.String");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(string)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(string);
-    Property.Builder age = new Property.Builder()
+        .setType(string)
+        .build();
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setBoxedType(newTopLevelClass("java.lang.Integer"))
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(INT);
+        .setType(INT)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -3338,41 +3345,44 @@ public class DefaultSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                name.build(), false))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                age.build(), false))
-            .build())
+        .addProperties(name, age)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, name, false))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, age, false))
+            .build())
+        .build();
   }
 
   private static Metadata createMetadataWithDefaults() {
     QualifiedName person = QualifiedName.of("com.example", "Person");
     TypeMirror string = newTopLevelClass("java.lang.String");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(string)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(string);
-    Property.Builder age = new Property.Builder()
+        .setType(string)
+        .build();
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setBoxedType(newTopLevelClass("java.lang.Integer"))
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(INT);
+        .setType(INT)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -3380,40 +3390,43 @@ public class DefaultSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                name.build(), true))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                age.build(), true))
-            .build())
+        .addProperties(name, age)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, name, true))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, age, true))
+            .build())
+        .build();
   }
 
   private static Metadata createMetadataWithGenerics() {
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     TypeVariable typeVariableA = newTypeVariable("A");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(typeVariableA);
+        .setType(typeVariableA)
+        .build();
     TypeVariable typeVariableB = newTypeVariable("B");
-    Property.Builder age = new Property.Builder()
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(typeVariableB);
+        .setType(typeVariableB)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters("A", "B"))
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -3421,19 +3434,20 @@ public class DefaultSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters("A", "B"))
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters("A", "B"))
-        .addProperties(name
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                name.build(), false))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(
-                age.build(), false))
-            .build())
+        .addProperties(name, age)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters("A", "B"))
         .setValueType(generatedBuilder.nestedType("Value").withParameters("A", "B"))
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, name, false))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new DefaultPropertyFactory.CodeGenerator(metadata, age, false))
+            .build())
+        .build();
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -1000,22 +1000,24 @@ public class GuavaOptionalSourceTest {
     GenericTypeMirrorImpl optionalString = optional.newMirror(string);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(optionalString)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(optionalString);
-    Property.Builder age = new Property.Builder()
+        .setType(optionalString)
+        .build();
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setBoxedType(optionalInteger)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(optionalInteger);
+        .setType(optionalInteger)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1023,19 +1025,22 @@ public class GuavaOptionalSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
-                name.build(), OptionalType.GUAVA, string, Optional.<TypeMirror>absent(), false))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
-                age.build(), OptionalType.GUAVA, integer, Optional.<TypeMirror>of(INT), false))
-            .build())
+        .addProperties(name, age)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
+                metadata, name, OptionalType.GUAVA, string, Optional.<TypeMirror>absent(), false))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
+                metadata, age, OptionalType.GUAVA, integer, Optional.<TypeMirror>of(INT), false))
+            .build())
+        .build();
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -708,22 +708,24 @@ public class JavaUtilOptionalSourceTest {
     GenericTypeMirrorImpl optionalString = optional.newMirror(string);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(optionalString)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(optionalString);
-    Property.Builder age = new Property.Builder()
+        .setType(optionalString)
+        .build();
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setBoxedType(optionalInteger)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(optionalInteger);
+        .setType(optionalInteger)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -731,19 +733,22 @@ public class JavaUtilOptionalSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
-                name.build(), OptionalType.JAVA8, string, Optional.<TypeMirror>absent(), false))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
-                age.build(), OptionalType.JAVA8, integer, Optional.<TypeMirror>of(INT), false))
-            .build())
+        .addProperties(name, age)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
+                metadata, name, OptionalType.JAVA8, string, Optional.<TypeMirror>absent(), false))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new OptionalPropertyFactory.CodeGenerator(
+                metadata, age, OptionalType.JAVA8, integer, Optional.<TypeMirror>of(INT), false))
+            .build())
+        .build();
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -1227,22 +1227,24 @@ public class ListSourceTest {
     GenericTypeMirrorImpl listString = list.newMirror(string);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(listString)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(listString);
-    Property.Builder age = new Property.Builder()
+        .setType(listString)
+        .build();
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setBoxedType(listInteger)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(listInteger);
+        .setType(listInteger)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1250,19 +1252,22 @@ public class ListSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
-                name.build(), false, string, Optional.<TypeMirror>absent()))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
-                age.build(), false, integer, Optional.<TypeMirror>of(INT)))
-            .build())
+        .addProperties(name, age)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
+                metadata, name, false, string, Optional.<TypeMirror>absent()))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
+                metadata, age, false, integer, Optional.<TypeMirror>of(INT)))
+            .build())
+        .build();
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -867,14 +867,15 @@ public class MapSourceTest {
     GenericTypeMirrorImpl mapIntString = map.newMirror(integer, string);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(mapIntString)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(mapIntString);
+        .setType(mapIntString)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -882,20 +883,24 @@ public class MapSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
+        .addProperties(name)
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
             .setCodeGenerator(new MapPropertyFactory.CodeGenerator(
-                name.build(),
+                metadata,
+                name,
                 false,
                 integer,
                 Optional.<TypeMirror>of(INT),
                 string,
                 Optional.<TypeMirror>absent()))
             .build())
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/NullablePropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullablePropertyFactoryTest.java
@@ -27,6 +27,7 @@ import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.NullablePropertyFactory.CodeGenerator;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +44,12 @@ public class NullablePropertyFactoryTest {
   @Rule public final ModelRule model = new ModelRule();
   @Mock(answer = RETURNS_SMART_NULLS) private Config config;
   private final NullablePropertyFactory factory = new NullablePropertyFactory();
+  @Mock(answer = RETURNS_SMART_NULLS) private Metadata metadata;
+
+  @Before
+  public void setUp() {
+    when(config.getMetadata()).thenReturn(metadata);
+  }
 
   @Test
   public void notNullable() {
@@ -80,7 +87,7 @@ public class NullablePropertyFactoryTest {
     Optional<CodeGenerator> codeGenerator = factory.create(config);
 
     assertThat(codeGenerator).hasValue(new NullablePropertyFactory.CodeGenerator(
-        property, ImmutableSet.of(model.typeElement(Nullable.class))));
+        metadata, property, ImmutableSet.of(model.typeElement(Nullable.class))));
   }
 
   @Test
@@ -103,7 +110,7 @@ public class NullablePropertyFactoryTest {
     Optional<CodeGenerator> codeGenerator = factory.create(config);
 
     assertThat(codeGenerator).hasValue(new NullablePropertyFactory.CodeGenerator(
-        property, ImmutableSet.of(model.typeElement("foo.bar.Nullable"))));
+        metadata, property, ImmutableSet.of(model.typeElement("foo.bar.Nullable"))));
   }
 
   @Test
@@ -129,7 +136,7 @@ public class NullablePropertyFactoryTest {
     Optional<CodeGenerator> codeGenerator = factory.create(config);
 
     assertThat(codeGenerator).hasValue(new NullablePropertyFactory.CodeGenerator(
-        property, ImmutableSet.of(
+        metadata, property, ImmutableSet.of(
             model.typeElement(Nullable.class), model.typeElement("foo.bar.Nullable"))));
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -697,22 +697,24 @@ public class NullableSourceTest {
     ClassElementImpl nullable = newTopLevelClass("javax.annotation.Nullable").asElement();
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(string)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(string);
-    Property.Builder age = new Property.Builder()
+        .setType(string)
+        .build();
+    Property age = new Property.Builder()
         .setAllCapsName("AGE")
         .setBoxedType(integer)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
         .setName("age")
-        .setType(integer);
+        .setType(integer)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -720,19 +722,22 @@ public class NullableSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new NullablePropertyFactory.CodeGenerator(
-                name.build(), ImmutableSet.of(nullable)))
-            .build())
-        .addProperties(age
-            .setCodeGenerator(new NullablePropertyFactory.CodeGenerator(
-                age.build(), ImmutableSet.of(nullable)))
-            .build())
+        .addProperties(name, age)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new NullablePropertyFactory.CodeGenerator(
+                metadata, name, ImmutableSet.of(nullable)))
+            .build())
+        .addProperties(age.toBuilder()
+            .setCodeGenerator(new NullablePropertyFactory.CodeGenerator(
+                metadata, age, ImmutableSet.of(nullable)))
+            .build())
+        .build();
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -1153,14 +1153,15 @@ public class SetSourceTest {
     GenericTypeMirrorImpl setString = set.newMirror(string);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
-    Property.Builder name = new Property.Builder()
+    Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(setString)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(setString);
+        .setType(setString)
+        .build();
     Metadata metadata = new Metadata.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1168,15 +1169,18 @@ public class SetSourceTest {
         .setGeneratedBuilder(generatedBuilder.withParameters())
         .setInterfaceType(false)
         .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name
-            .setCodeGenerator(new SetPropertyFactory.CodeGenerator(
-                name.build(), string, Optional.<TypeMirror>absent(), false))
-            .build())
+        .addProperties(name)
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return metadata;
+    return metadata.toBuilder()
+        .clearProperties()
+        .addProperties(name.toBuilder()
+            .setCodeGenerator(new SetPropertyFactory.CodeGenerator(
+                metadata, name, string, Optional.<TypeMirror>absent(), false))
+            .build())
+        .build();
   }
 
 }


### PR DESCRIPTION
Rather than passing metadata to individual CodeGenerator methods, instead pass it to the CodeGenerator factories. This necessitates first creating a complete Metadata instance with no CodeGenerators, to break the chicken-and-egg paradox that is otherwise implied.