### PR TITLE
Make excerpts extend ValueType

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
@@ -22,8 +22,8 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.ParameterizedType;
-import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import java.util.Set;
 
@@ -40,15 +40,11 @@ public enum BuilderFactory {
     @Override public Excerpt newBuilder(
         final ParameterizedType builderType,
         final TypeInference typeInference) {
-      return new Excerpt() {
-        @Override public void addTo(SourceBuilder code) {
-          if (typeInference == TypeInference.INFERRED_TYPES) {
-            code.add("%s()", builderType.constructor());
-          } else {
-            code.add("new %s()", builderType);
-          }
-        }
-      };
+      if (typeInference == TypeInference.INFERRED_TYPES) {
+        return Excerpts.add("%s()", builderType.constructor());
+      } else {
+        return Excerpts.add("new %s()", builderType);
+      }
     }
   },
 
@@ -57,16 +53,12 @@ public enum BuilderFactory {
     @Override public Excerpt newBuilder(
         final ParameterizedType builderType,
         final TypeInference typeInference) {
-      return new Excerpt() {
-        @Override public void addTo(SourceBuilder code) {
-          if (typeInference == TypeInference.INFERRED_TYPES) {
-            code.add("%s.builder()", builderType.getQualifiedName().getEnclosingType());
-          } else {
-            code.add("%s.%sbuilder()",
-                builderType.getQualifiedName().getEnclosingType(), builderType.typeParameters());
-          }
-        }
-      };
+      if (typeInference == TypeInference.INFERRED_TYPES) {
+        return Excerpts.add("%s.builder()", builderType.getQualifiedName().getEnclosingType());
+      } else {
+        return Excerpts.add("%s.%sbuilder()",
+            builderType.getQualifiedName().getEnclosingType(), builderType.typeParameters());
+      }
     }
   },
 
@@ -75,16 +67,12 @@ public enum BuilderFactory {
     @Override public Excerpt newBuilder(
         final ParameterizedType builderType,
         final TypeInference typeInference) {
-      return new Excerpt() {
-        @Override public void addTo(SourceBuilder code) {
-          if (typeInference == TypeInference.INFERRED_TYPES) {
-            code.add("%s.newBuilder()", builderType.getQualifiedName().getEnclosingType());
-          } else {
-            code.add("%s.%snewBuilder()",
-                builderType.getQualifiedName().getEnclosingType(), builderType.typeParameters());
-          }
-        }
-      };
+      if (typeInference == TypeInference.INFERRED_TYPES) {
+        return Excerpts.add("%s.newBuilder()", builderType.getQualifiedName().getEnclosingType());
+      } else {
+        return Excerpts.add("%s.%snewBuilder()",
+            builderType.getQualifiedName().getEnclosingType(), builderType.typeParameters());
+      }
     }
   };
 

--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -40,6 +40,7 @@ import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.Metadata.StandardMethod;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
 import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 
@@ -785,15 +786,7 @@ public class CodeGenerator {
 
   /** Returns an {@link Excerpt} of "implements/extends {@code type}". */
   private static Excerpt extending(final Object type, final boolean isInterface) {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        if (isInterface) {
-          source.add("implements %s", type);
-        } else {
-          source.add("extends %s", type);
-        }
-      }
-    };
+    return Excerpts.add(isInterface ? "implements %s" : "extends %s", type);
   }
 
   private static ImmutableList<String> getNames(Iterable<Property> properties) {

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultPropertyFactory.java
@@ -29,6 +29,7 @@ import com.google.common.base.Optional;
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
 import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
@@ -147,13 +148,8 @@ public class DefaultPropertyFactory implements PropertyCodeGenerator.Factory {
       code.addLine(" */")
           .addLine("public %s %s() {", property.getType(), getter(property));
       if (!hasDefault) {
-        Excerpt propertyIsSet = new Excerpt() {
-          @Override
-          public void addTo(SourceBuilder source) {
-            source.add("!_unsetProperties.contains(%s.%s)",
+        Excerpt propertyIsSet = Excerpts.add("!_unsetProperties.contains(%s.%s)",
                 metadata.getPropertyEnum(), property.getAllCapsName());
-          }
-        };
         code.add(PreconditionExcerpts.checkState(propertyIsSet, property.getName() + " not set"));
       }
       code.addLine("  return %s;", property.getName())

--- a/src/main/java/org/inferred/freebuilder/processor/GwtSupport.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GwtSupport.java
@@ -10,6 +10,7 @@ import com.google.common.base.Optional;
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.Metadata.Visibility;
 import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 
@@ -31,13 +32,14 @@ class GwtSupport {
   public static void addGwtMetadata(TypeElement type, Metadata.Builder metadata) {
     Optional<AnnotationMirror> annotation = findAnnotationMirror(type, GwtCompatible.class);
     if (annotation.isPresent()) {
-      metadata.addGeneratedBuilderAnnotations(new GwtCompatibleExcerpt());
+      metadata.addGeneratedBuilderAnnotations(Excerpts.add("@%s%n", GwtCompatible.class));
       Optional<AnnotationValue> serializable = findProperty(annotation.get(), "serializable");
       if (serializable.isPresent() && serializable.get().getValue().equals(Boolean.TRUE)) {
         // Due to a bug in GWT's handling of nested types, we have to declare Value as package
         // scoped so Value_CustomFieldSerializer can access it.
         metadata.setValueTypeVisibility(Visibility.PACKAGE);
-        metadata.addValueTypeAnnotations(new GwtCompatibleAndSerializableExcerpt());
+        metadata.addValueTypeAnnotations(Excerpts.add(
+            "@%s(serializable = true)%n", GwtCompatible.class));
         metadata.addNestedClasses(new CustomValueSerializer());
         metadata.addNestedClasses(new GwtWhitelist());
         QualifiedName builderName = metadata.getGeneratedBuilder().getQualifiedName();
@@ -48,172 +50,164 @@ class GwtSupport {
     }
   }
 
-  private static class GwtCompatibleExcerpt implements Excerpt {
-    @Override
-    public void addTo(SourceBuilder code) {
-      code.addLine("@%s", GwtCompatible.class);
-    }
-  }
-
-  private static class GwtCompatibleAndSerializableExcerpt implements Excerpt {
-    @Override
-    public void addTo(SourceBuilder code) {
-      code.addLine("@%s(serializable = true)", GwtCompatible.class);
-    }
-  }
-
   private static final class CustomValueSerializer implements Function<Metadata, Excerpt> {
     @Override
     public Excerpt apply(final Metadata metadata) {
-      return new Excerpt() {
-        @Override
-        public void addTo(SourceBuilder code) {
-          addCustomValueSerializer(code, metadata);
+      return new CustomValueSerializerExcerpt(metadata);
+    }
+  }
+
+  private static final class CustomValueSerializerExcerpt extends Excerpt {
+    private final Metadata metadata;
+
+    private CustomValueSerializerExcerpt(Metadata metadata) {
+      this.metadata = metadata;
+    }
+
+    @Override
+    public void addTo(SourceBuilder code) {
+      code.addLine("")
+          .addLine("@%s", GwtCompatible.class);
+      if (metadata.getType().isParameterized()) {
+        code.addLine("@%s(\"unchecked\")", SuppressWarnings.class);
+      }
+      code.addLine("public static class Value_CustomFieldSerializer")
+          .addLine("    extends %s<%s> {", CUSTOM_FIELD_SERIALIZER, metadata.getValueType())
+          .addLine("")
+          .addLine("  @%s", Override.class)
+          .addLine("  public void deserializeInstance(%s reader, %s instance) { }",
+              SERIALIZATION_STREAM_READER, metadata.getValueType())
+          .addLine("")
+          .addLine("  @%s", Override.class)
+          .addLine("  public boolean hasCustomInstantiateInstance() {")
+          .addLine("    return true;")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @%s", Override.class)
+          .addLine("  public %s instantiateInstance(%s reader)",
+              metadata.getValueType(), SERIALIZATION_STREAM_READER)
+          .addLine("      throws %s {", SERIALIZATION_EXCEPTION)
+          .addLine("    %1$s builder = new %1$s();", metadata.getBuilder());
+      for (Property property : metadata.getProperties()) {
+        if (property.getType().getKind().isPrimitive()) {
+          code.addLine("      %s %s = reader.read%s();",
+              property.getType(), property.getName(), withInitialCapital(property.getType()));
+          property.getCodeGenerator()
+              .addSetFromResult(code, "builder", property.getName());
+        } else if (String.class.getName().equals(property.getType().toString())) {
+          code.addLine("      %s %s = reader.readString();",
+              property.getType(), property.getName());
+          property.getCodeGenerator()
+              .addSetFromResult(code, "builder", property.getName());
+        } else {
+          code.addLine("    try {");
+          if (!property.isFullyCheckedCast()) {
+            code.addLine("      @SuppressWarnings(\"unchecked\")");
+          }
+          code.addLine("      %1$s %2$s = (%1$s) reader.readObject();",
+                  property.getType(), property.getName());
+          property.getCodeGenerator()
+              .addSetFromResult(code, "builder", property.getName());
+          code.addLine("    } catch (%s e) {", ClassCastException.class)
+              .addLine("      throw new %s(", SERIALIZATION_EXCEPTION)
+              .addLine("          \"Wrong type for property '%s'\", e);", property.getName())
+              .addLine("    }");
         }
-      };
+      }
+      code.addLine("    return (%s) builder.build();", metadata.getValueType())
+          .addLine("  }")
+          .addLine("")
+          .addLine("  @%s", Override.class)
+          .addLine("  public void serializeInstance(%s writer, %s instance)",
+              SERIALIZATION_STREAM_WRITER, metadata.getValueType())
+          .addLine("      throws %s {", SERIALIZATION_EXCEPTION);
+      for (Property property : metadata.getProperties()) {
+        if (property.getType().getKind().isPrimitive()) {
+          code.add("    writer.write%s(",
+              withInitialCapital(property.getType()), property.getName());
+        } else if (String.class.getName().equals(property.getType().toString())) {
+          code.add("    writer.writeString(", property.getName());
+        } else {
+          code.add("    writer.writeObject(", property.getName());
+        }
+        property.getCodeGenerator().addReadValueFragment(code, "instance." + property.getName());
+        code.add(");\n");
+      }
+      code.addLine("  }")
+          .addLine("")
+          .addLine("  private static final Value_CustomFieldSerializer INSTANCE ="
+              + " new Value_CustomFieldSerializer();")
+          .addLine("")
+          .addLine("  public static void deserialize(%s reader, %s instance) {",
+              SERIALIZATION_STREAM_READER, metadata.getValueType())
+          .addLine("    INSTANCE.deserializeInstance(reader, instance);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  public static %s instantiate(%s reader)",
+              metadata.getValueType(), SERIALIZATION_STREAM_READER)
+          .addLine("      throws %s {", SERIALIZATION_EXCEPTION)
+          .addLine("    return INSTANCE.instantiateInstance(reader);")
+          .addLine("  }")
+          .addLine("")
+          .addLine("  public static void serialize(%s writer, %s instance)",
+              SERIALIZATION_STREAM_WRITER, metadata.getValueType())
+          .addLine("      throws %s {", SERIALIZATION_EXCEPTION)
+          .addLine("    INSTANCE.serializeInstance(writer, instance);")
+          .addLine("  }")
+          .addLine("}");
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("metadata", metadata);
     }
   }
 
   private static final class GwtWhitelist implements Function<Metadata, Excerpt> {
     @Override
     public Excerpt apply(final Metadata metadata) {
-      return new Excerpt() {
-        @Override
-        public void addTo(SourceBuilder code) {
-          addGwtWhitelistType(code, metadata);
-        }
-      };
+      return new GwtWhitelistExcerpt(metadata);
     }
   }
 
-  private static void addCustomValueSerializer(SourceBuilder code, Metadata metadata) {
-    code.addLine("")
-        .addLine("@%s", GwtCompatible.class);
-    if (metadata.getType().isParameterized()) {
-      code.addLine("@%s(\"unchecked\")", SuppressWarnings.class);
-    }
-    code.addLine("public static class Value_CustomFieldSerializer")
-        .addLine("    extends %s<%s> {", CUSTOM_FIELD_SERIALIZER, metadata.getValueType())
-        .addLine("")
-        .addLine("  @%s", Override.class)
-        .addLine("  public void deserializeInstance(%s reader, %s instance) { }",
-            SERIALIZATION_STREAM_READER, metadata.getValueType())
-        .addLine("")
-        .addLine("  @%s", Override.class)
-        .addLine("  public boolean hasCustomInstantiateInstance() {")
-        .addLine("    return true;")
-        .addLine("  }")
-        .addLine("")
-        .addLine("  @%s", Override.class)
-        .addLine("  public %s instantiateInstance(%s reader)",
-            metadata.getValueType(), SERIALIZATION_STREAM_READER)
-        .addLine("      throws %s {", SERIALIZATION_EXCEPTION)
-        .addLine("    %1$s builder = new %1$s();", metadata.getBuilder());
-    for (Property property : metadata.getProperties()) {
-      if (property.getType().getKind().isPrimitive()) {
-        code.addLine("      %s %s = reader.read%s();",
-            property.getType(), property.getName(), withInitialCapital(property.getType()));
-        property.getCodeGenerator()
-            .addSetFromResult(code, "builder", property.getName());
-      } else if (String.class.getName().equals(property.getType().toString())) {
-        code.addLine("      %s %s = reader.readString();",
-            property.getType(), property.getName());
-        property.getCodeGenerator()
-            .addSetFromResult(code, "builder", property.getName());
-      } else {
-        code.addLine("    try {");
-        if (!property.isFullyCheckedCast()) {
-          code.addLine("      @SuppressWarnings(\"unchecked\")");
-        }
-        code.addLine("      %1$s %2$s = (%1$s) reader.readObject();",
-                property.getType(), property.getName());
-        property.getCodeGenerator()
-            .addSetFromResult(code, "builder", property.getName());
-        code.addLine("    } catch (%s e) {", ClassCastException.class)
-            .addLine("      throw new %s(", SERIALIZATION_EXCEPTION)
-            .addLine("          \"Wrong type for property '%s'\", e);", property.getName())
-            .addLine("    }");
-      }
-    }
-    code.addLine("    return (%s) builder.build();", metadata.getValueType())
-        .addLine("  }")
-        .addLine("")
-        .addLine("  @%s", Override.class)
-        .addLine("  public void serializeInstance(%s writer, %s instance)",
-            SERIALIZATION_STREAM_WRITER, metadata.getValueType())
-        .addLine("      throws %s {", SERIALIZATION_EXCEPTION);
-    for (Property property : metadata.getProperties()) {
-      if (property.getType().getKind().isPrimitive()) {
-        code.add("    writer.write%s(",
-            withInitialCapital(property.getType()), property.getName());
-      } else if (String.class.getName().equals(property.getType().toString())) {
-        code.add("    writer.writeString(", property.getName());
-      } else {
-        code.add("    writer.writeObject(", property.getName());
-      }
-      property.getCodeGenerator().addReadValueFragment(code, "instance." + property.getName());
-      code.add(");\n");
-    }
-    code.addLine("  }")
-        .addLine("")
-        .addLine("  private static final Value_CustomFieldSerializer INSTANCE ="
-            + " new Value_CustomFieldSerializer();")
-        .addLine("")
-        .addLine("  public static void deserialize(%s reader, %s instance) {",
-            SERIALIZATION_STREAM_READER, metadata.getValueType())
-        .addLine("    INSTANCE.deserializeInstance(reader, instance);")
-        .addLine("  }")
-        .addLine("")
-        .addLine("  public static %s instantiate(%s reader)",
-            metadata.getValueType(), SERIALIZATION_STREAM_READER)
-        .addLine("      throws %s {", SERIALIZATION_EXCEPTION)
-        .addLine("    return INSTANCE.instantiateInstance(reader);")
-        .addLine("  }")
-        .addLine("")
-        .addLine("  public static void serialize(%s writer, %s instance)",
-            SERIALIZATION_STREAM_WRITER, metadata.getValueType())
-        .addLine("      throws %s {", SERIALIZATION_EXCEPTION)
-        .addLine("    INSTANCE.serializeInstance(writer, instance);")
-        .addLine("  }")
-        .addLine("}");
-  }
+  private static final class GwtWhitelistExcerpt extends Excerpt {
+    private final Metadata metadata;
 
-  private static void addGwtWhitelistType(SourceBuilder code, Metadata metadata) {
-    code.addLine("")
-        .addLine("/** This class exists solely to ensure GWT whitelists all required types. */")
-        .addLine("@%s(serializable = true)", GwtCompatible.class)
-        .addLine("static final class GwtWhitelist%s %s {",
-            metadata.getType().declarationParameters(),
-            extending(metadata.getType(), metadata.isInterfaceType()))
-        .addLine("");
-    for (Property property : metadata.getProperties()) {
-      code.addLine("  %s %s;", property.getType(), property.getName());
+    private GwtWhitelistExcerpt(Metadata metadata) {
+      this.metadata = metadata;
     }
-    code.addLine("")
-        .addLine("  private GwtWhitelist() {")
-        .addLine("    throw new %s();", UnsupportedOperationException.class)
-        .addLine("   }");
-    for (Property property : metadata.getProperties()) {
+
+    @Override
+    public void addTo(SourceBuilder code) {
       code.addLine("")
-          .addLine("  @%s", Override.class)
-          .addLine("  public %s %s() {", property.getType(), property.getGetterName())
-          .addLine("    throw new %s();", UnsupportedOperationException.class)
-          .addLine("  }");
-    }
-    code.addLine("}");
-  }
-
-  /** Returns an {@link Excerpt} of "implements/extends {@code type}". */
-  private static Excerpt extending(final Object type, final boolean isInterface) {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        if (isInterface) {
-          source.add("implements %s", type);
-        } else {
-          source.add("extends %s", type);
-        }
+          .addLine("/** This class exists solely to ensure GWT whitelists all required types. */")
+          .addLine("@%s(serializable = true)", GwtCompatible.class)
+          .addLine("static final class GwtWhitelist%s %s %s {",
+              metadata.getType().declarationParameters(),
+              metadata.isInterfaceType() ? "implements " : "extends ",
+              metadata.getType())
+          .addLine("");
+      for (Property property : metadata.getProperties()) {
+        code.addLine("  %s %s;", property.getType(), property.getName());
       }
-    };
+      code.addLine("")
+          .addLine("  private GwtWhitelist() {")
+          .addLine("    throw new %s();", UnsupportedOperationException.class)
+          .addLine("   }");
+      for (Property property : metadata.getProperties()) {
+        code.addLine("")
+            .addLine("  @%s", Override.class)
+            .addLine("  public %s %s() {", property.getType(), property.getGetterName())
+            .addLine("    throw new %s();", UnsupportedOperationException.class)
+            .addLine("  }");
+      }
+      code.addLine("}");
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("metadata", metadata);
+    }
   }
 
   private static String withInitialCapital(Object obj) {

--- a/src/main/java/org/inferred/freebuilder/processor/JacksonSupport.java
+++ b/src/main/java/org/inferred/freebuilder/processor/JacksonSupport.java
@@ -6,9 +6,8 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.QualifiedName;
-import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import java.util.Set;
 
@@ -42,9 +41,10 @@ class JacksonSupport {
       Property.Builder resultBuilder, ExecutableElement getterMethod) {
     Optional<AnnotationMirror> annotation = findAnnotationMirror(getterMethod, JSON_PROPERTY);
     if (annotation.isPresent()) {
-      resultBuilder.addAccessorAnnotations(new AnnotationExcerpt(annotation.get()));
+      resultBuilder.addAccessorAnnotations(Excerpts.add("%s%n", annotation.get()));
     } else if (generateDefaultAnnotations(getterMethod)) {
-      resultBuilder.addAccessorAnnotations(new JsonPropertyExcerpt(resultBuilder.getName()));
+      resultBuilder.addAccessorAnnotations(Excerpts.add(
+          "@%s(\"%s\")%n", JSON_PROPERTY, resultBuilder.getName()));
     }
   }
 
@@ -58,34 +58,6 @@ class JacksonSupport {
       }
     }
     return true;
-  }
-
-  private static class AnnotationExcerpt implements Excerpt {
-
-    private final AnnotationMirror annotation;
-
-    AnnotationExcerpt(AnnotationMirror annotation) {
-      this.annotation = annotation;
-    }
-
-    @Override
-    public void addTo(SourceBuilder code) {
-      code.addLine("%s", annotation);
-    }
-  }
-
-  private static class JsonPropertyExcerpt implements Excerpt {
-
-    private final String propertyName;
-
-    JsonPropertyExcerpt(String propertyName) {
-      this.propertyName = propertyName;
-    }
-
-    @Override
-    public void addTo(SourceBuilder code) {
-      code.addLine("@%s(\"%s\")", JSON_PROPERTY, propertyName);
-    }
   }
 
 }

--- a/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListPropertyFactory.java
@@ -31,6 +31,7 @@ import static org.inferred.freebuilder.processor.util.StaticExcerpt.Type.METHOD;
 import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
 import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.diamondOperator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -112,11 +113,12 @@ public class ListPropertyFactory implements PropertyCodeGenerator.Factory {
 
     @Override
     public void addBuilderFieldDeclaration(SourceBuilder code) {
-      code.addLine("private final %1$s<%2$s> %3$s = new %1$s<%4$s>();",
+      code.feature(SOURCE_LEVEL);
+      code.addLine("private final %1$s<%2$s> %3$s = new %1$s%4$s();",
           ArrayList.class,
           elementType,
           property.getName(),
-          code.feature(SOURCE_LEVEL).supportsDiamondOperator() ? "" : elementType);
+          diamondOperator(elementType));
     }
 
     @Override

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata.java
@@ -22,7 +22,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Ordering;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.ParameterizedType;
@@ -52,22 +51,39 @@ public abstract class Metadata {
     FINAL;
   }
 
-  public enum Visibility implements Excerpt {
-    PUBLIC("public "), PROTECTED("protected "), PACKAGE(""), PRIVATE("private ");
+  public static class Visibility extends Excerpt {
+    public static final Visibility PUBLIC = new Visibility(0, "PUBLIC", "public ");
+    public static final Visibility PROTECTED = new Visibility(1, "PROTECTED", "protected ");
+    public static final Visibility PACKAGE = new Visibility(2, "PACKAGE", "");
+    public static final Visibility PRIVATE = new Visibility(3, "PRIVATE", "private ");
 
+    private final int order;
+    private final String name;
     private final String excerpt;
 
-    Visibility(String excerpt) {
+    Visibility(int order, String name, String excerpt) {
+      this.order = order;
+      this.name = name;
       this.excerpt = excerpt;
     }
 
     public static Visibility mostVisible(Visibility a, Visibility b) {
-      return Ordering.natural().min(a, b);
+      return (a.order < b.order) ? a : b;
     }
 
     @Override
     public void addTo(SourceBuilder code) {
       code.add(excerpt);
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("excerpt", excerpt);
     }
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
@@ -32,6 +32,7 @@ import static org.inferred.freebuilder.processor.util.StaticExcerpt.Type.METHOD;
 import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
 import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.diamondOperator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -104,11 +105,9 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
 
     @Override
     public void addBuilderFieldDeclaration(SourceBuilder code) {
-      code.addLine("private final %1$s<%2$s> %3$s = new %1$s<%4$s>();",
-          LinkedHashSet.class,
-          elementType,
-          property.getName(),
-          code.feature(SOURCE_LEVEL).supportsDiamondOperator() ? "" : elementType);
+      code.feature(SOURCE_LEVEL);
+      code.addLine("private final %1$s<%2$s> %3$s = new %1$s%4$s();",
+          LinkedHashSet.class, elementType, property.getName(), diamondOperator(elementType));
     }
 
     @Override
@@ -356,11 +355,8 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
             .addLine("  case 1:")
             .addLine("    return %s.singleton(elements.iterator().next());", Collections.class)
             .addLine("  default:")
-            .add("    return %s.unmodifiableSet(new %s<", Collections.class, LinkedHashSet.class);
-        if (!code.feature(SOURCE_LEVEL).supportsDiamondOperator()) {
-          code.add("E");
-        }
-        code.add(">(elements));\n")
+            .addLine("    return %s.unmodifiableSet(new %s%s(elements));",
+                Collections.class, LinkedHashSet.class, diamondOperator("E"))
             .addLine("  }")
             .addLine("}");
       }

--- a/src/main/java/org/inferred/freebuilder/processor/util/Excerpt.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Excerpt.java
@@ -18,6 +18,6 @@ package org.inferred.freebuilder.processor.util;
 /**
  * An object representing a source code excerpt, e.g. a type.
  */
-public interface Excerpt {
-  void addTo(SourceBuilder source);
+public abstract class Excerpt extends ValueType {
+  public abstract void addTo(SourceBuilder source);
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class Excerpts {
 
-  private static final class AddingExcerpt extends ValueType implements Excerpt {
+  private static final class AddingExcerpt extends Excerpt {
     private final String fmt;
     private final Object[] args;
 
@@ -46,9 +46,12 @@ public class Excerpts {
     return new AddingExcerpt(fmt, args);
   }
 
-  private static final class EmptyExcerpt implements Excerpt {
+  private static final class EmptyExcerpt extends Excerpt {
     @Override
     public void addTo(SourceBuilder source) {}
+
+    @Override
+    protected void addFields(FieldReceiver fields) {}
   }
 
   private static final Excerpt EMPTY = new EmptyExcerpt();
@@ -57,7 +60,7 @@ public class Excerpts {
     return EMPTY;
   }
 
-  private static final class JoiningExcerpt extends ValueType implements Excerpt {
+  private static final class JoiningExcerpt extends Excerpt {
     private final String separator;
     private final List<?> excerpts;
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
@@ -1,0 +1,90 @@
+package org.inferred.freebuilder.processor.util;
+
+import static java.util.Arrays.asList;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class Excerpts {
+
+  private static final class AddingExcerpt extends ValueType implements Excerpt {
+    private final String fmt;
+    private final Object[] args;
+
+    private AddingExcerpt(String fmt, Object[] args) {
+      this.args = args;
+      this.fmt = fmt;
+    }
+
+    @Override
+    public void addTo(SourceBuilder source) {
+      source.add(fmt, args);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder result = new StringBuilder()
+          .append("Excerpts.add(\"")
+          .append(fmt.replaceAll("[\\\"]", "\\\1"))
+          .append('"');
+      for (Object arg : args) {
+        result.append(", ").append(arg);
+      }
+      result.append(")");
+      return result.toString();
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("fmt", fmt);
+      fields.add("args", asList(args));
+    }
+  }
+
+  public static Excerpt add(final String fmt, final Object... args) {
+    return new AddingExcerpt(fmt, args);
+  }
+
+  private static final class EmptyExcerpt implements Excerpt {
+    @Override
+    public void addTo(SourceBuilder source) {}
+  }
+
+  private static final Excerpt EMPTY = new EmptyExcerpt();
+
+  public static Excerpt empty() {
+    return EMPTY;
+  }
+
+  private static final class JoiningExcerpt extends ValueType implements Excerpt {
+    private final String separator;
+    private final List<?> excerpts;
+
+    private JoiningExcerpt(String separator, Iterable<?> excerpts) {
+      this.separator = separator;
+      this.excerpts = ImmutableList.copyOf(excerpts);
+    }
+
+    @Override
+    public void addTo(SourceBuilder source) {
+      String itemPrefix = "";
+      for (Object object : excerpts) {
+        source.add("%s%s", itemPrefix, object);
+        itemPrefix = separator;
+      }
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("separator", separator);
+      fields.add("excerpts", excerpts);
+    }
+  }
+
+  public static Object join(final String separator, final Iterable<?> excerpts) {
+    return new JoiningExcerpt(separator, excerpts);
+  }
+
+  private Excerpts() {}
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
@@ -39,7 +39,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleElementVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
 
-public class ParameterizedType extends ValueType implements Excerpt {
+public class ParameterizedType extends Excerpt {
 
   public static ParameterizedType from(TypeElement typeElement) {
     return new ParameterisedTypeForElementVisitor().visitType(typeElement, null);
@@ -136,26 +136,7 @@ public class ParameterizedType extends ValueType implements Excerpt {
    * brackets.
    */
   public Excerpt declarationParameters() {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        if (!typeParameters.isEmpty()) {
-          String prefix = "<";
-          for (Object typeParameter : typeParameters) {
-            source.add("%s%s", prefix, typeParameter);
-            if (typeParameter instanceof TypeParameterElement) {
-              TypeParameterElement element = (TypeParameterElement) typeParameter;
-              String separator = " extends ";
-              for (TypeMirror bound : element.getBounds()) {
-                source.add("%s%s", separator, bound);
-                separator = " & ";
-              }
-            }
-            prefix = ", ";
-          }
-          source.add(">");
-        }
-      }
-    };
+    return new DeclarationParameters(typeParameters);
   }
 
   /**
@@ -184,6 +165,39 @@ public class ParameterizedType extends ValueType implements Excerpt {
   protected void addFields(FieldReceiver fields) {
     fields.add("qualifiedName", qualifiedName);
     fields.add("typeParameters", typeParameters);
+  }
+
+  private final class DeclarationParameters extends Excerpt {
+
+    private final List<?> typeParameters;
+
+    DeclarationParameters(List<?> typeParameters) {
+      this.typeParameters = typeParameters;
+    }
+
+    @Override public void addTo(SourceBuilder source) {
+      if (!typeParameters.isEmpty()) {
+        String prefix = "<";
+        for (Object typeParameter : typeParameters) {
+          source.add("%s%s", prefix, typeParameter);
+          if (typeParameter instanceof TypeParameterElement) {
+            TypeParameterElement element = (TypeParameterElement) typeParameter;
+            String separator = " extends ";
+            for (TypeMirror bound : element.getBounds()) {
+              source.add("%s%s", separator, bound);
+              separator = " & ";
+            }
+          }
+          prefix = ", ";
+        }
+        source.add(">");
+      }
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("typeParameters", typeParameters);
+    }
   }
 
   private static final class ParameterisedTypeForElementVisitor

--- a/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
@@ -18,9 +18,11 @@ package org.inferred.freebuilder.processor.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.transform;
+
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.diamondOperator;
+
 import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
-import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -105,44 +107,28 @@ public class ParameterizedType extends ValueType implements Excerpt {
    * in full.
    */
   public Excerpt constructor() {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        if (isParameterized() && source.feature(SOURCE_LEVEL).supportsDiamondOperator()) {
-          source.add("new %s<>", qualifiedName);
-        } else {
-          source.add("new %s", ParameterizedType.this);
-        }
-      }
-    };
+    return Excerpts.add(
+        "new %s%s",
+        qualifiedName,
+        isParameterized() ? diamondOperator(Excerpts.join(", ", typeParameters)) : "");
   }
 
   /**
    * Returns a source excerpt suitable for declaring this type, i.e. {@code SimpleName<...>}
    */
   public Excerpt declaration() {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        source.add("%s%s", qualifiedName.getSimpleName(), declarationParameters());
-      }
-    };
+    return Excerpts.add("%s%s", qualifiedName.getSimpleName(), declarationParameters());
   }
 
   /**
    * Returns a source excerpt of the type parameters of this type, including angle brackets.
    */
   public Excerpt typeParameters() {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        if (!typeParameters.isEmpty()) {
-          String prefix = "<";
-          for (Object typeParameter : typeParameters) {
-            source.add("%s%s", prefix, typeParameter);
-            prefix = ", ";
-          }
-          source.add(">");
-        }
-      }
-    };
+    if (typeParameters.isEmpty()) {
+      return Excerpts.empty();
+    } else {
+      return Excerpts.add("<%s>", Excerpts.join(", ", typeParameters));
+    }
   }
 
   /**
@@ -176,22 +162,14 @@ public class ParameterizedType extends ValueType implements Excerpt {
    * Returns a source excerpt of a JavaDoc link to this type.
    */
   public Excerpt javadocLink() {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        source.add("{@link %s}", getQualifiedName());
-      }
-    };
+    return Excerpts.add("{@link %s}", getQualifiedName());
   }
 
   /**
    * Returns a source excerpt of a JavaDoc link to a no-args method on this type.
    */
   public Excerpt javadocNoArgMethodLink(final String memberName) {
-    return new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        source.add("{@link %s#%s()}", getQualifiedName(), memberName);
-      }
-    };
+    return Excerpts.add("{@link %s#%s()}", getQualifiedName(), memberName);
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/StaticExcerpt.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/StaticExcerpt.java
@@ -2,7 +2,7 @@ package org.inferred.freebuilder.processor.util;
 
 import com.google.common.collect.ComparisonChain;
 
-public abstract class StaticExcerpt implements Excerpt, Comparable<StaticExcerpt> {
+public abstract class StaticExcerpt extends Excerpt implements Comparable<StaticExcerpt> {
 
   public enum Type { METHOD, TYPE }
 
@@ -28,5 +28,11 @@ public abstract class StaticExcerpt implements Excerpt, Comparable<StaticExcerpt
         .compare(getType(), o.getType())
         .compare(getName(), o.getName())
         .result();
+  }
+
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    fields.add("type", type);
+    fields.add("name", name);
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/Feature.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/Feature.java
@@ -9,9 +9,9 @@ import org.inferred.freebuilder.processor.util.SourceBuilder;
  *
  * <p>A feature will typically provide a {@link FeatureType} constant that can be passed to
  * {@code SourceBuilder#feature(FeatureType)} to determine the current status of a feature.
- * For instance, to determine whether the diamond operator is available for use:
+ * For instance, to determine whether {@code java.util.Objects} is available for use:
  *
  * <pre>code.feature({@link SourceLevel#SOURCE_LEVEL
- *     SOURCE_LEVEL}).{@link SourceLevel#supportsDiamondOperator() supportsDiamondOperator()}</pre>
+ *     SOURCE_LEVEL}).{@link SourceLevel#javaUtilObjects() javaUtilObjects()}.isPresent()</pre>
  */
 public interface Feature<T extends Feature<T>> {}

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
@@ -17,8 +17,10 @@ package org.inferred.freebuilder.processor.util.feature;
 
 import com.google.common.base.Optional;
 
+import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.ValueType;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.SourceVersion;
@@ -57,6 +59,37 @@ public enum SourceLevel implements Feature<SourceLevel> {
     }
   };
 
+  public static Excerpt diamondOperator(final Object type) {
+    return new DiamondOperator(type);
+  }
+
+  private static final class DiamondOperator extends ValueType implements Excerpt {
+    private final Object type;
+
+    private DiamondOperator(Object type) {
+      this.type = type;
+    }
+
+    @Override
+    public void addTo(SourceBuilder source) {
+      if (source.feature(SOURCE_LEVEL).compareTo(JAVA_7) >= 0) {
+        source.add("<>");
+      } else {
+        source.add("<%s>", type);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "diamondOperator(" + type + ")";
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("type", type);
+    }
+  }
+
   public Optional<QualifiedName> javaUtilObjects() {
     switch (this) {
       case JAVA_6:
@@ -65,9 +98,5 @@ public enum SourceLevel implements Feature<SourceLevel> {
       default:
         return Optional.of(QualifiedName.of("java.util", "Objects"));
     }
-  }
-
-  public boolean supportsDiamondOperator() {
-    return this.compareTo(JAVA_7) >= 0;
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
@@ -20,7 +20,6 @@ import com.google.common.base.Optional;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.ValueType;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.SourceVersion;
@@ -63,7 +62,7 @@ public enum SourceLevel implements Feature<SourceLevel> {
     return new DiamondOperator(type);
   }
 
-  private static final class DiamondOperator extends ValueType implements Excerpt {
+  private static final class DiamondOperator extends Excerpt {
     private final Object type;
 
     private DiamondOperator(Object type) {

--- a/src/test/java/org/inferred/freebuilder/processor/util/SourceStringBuilderTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/SourceStringBuilderTest.java
@@ -171,11 +171,7 @@ public class SourceStringBuilderTest {
 
   @Test
   public void testAddLine_excerpt() {
-    builder.addLine("%s = null;", new Excerpt() {
-      @Override public void addTo(SourceBuilder source) {
-        source.add("%s %s", "Foo", "bar");
-      }
-    });
+    builder.addLine("%s = null;", Excerpts.add("%s %s", "Foo", "bar"));
     assertThat(builder.toString()).isEqualTo("Foo bar = null;\n");
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/util/StaticExcerptTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/StaticExcerptTest.java
@@ -4,8 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.StaticExcerpt.Type.METHOD;
 import static org.inferred.freebuilder.processor.util.StaticExcerpt.Type.TYPE;
 
-import com.google.common.base.Objects;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,20 +22,6 @@ public class StaticExcerptTest {
     }
 
     @Override public void addTo(SourceBuilder source) {}
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(getType(), getName());
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof DummyStaticExcerpt)) {
-        return false;
-      }
-      DummyStaticExcerpt other = (DummyStaticExcerpt) obj;
-      return Objects.equal(getType(), other.getType()) && Objects.equal(getName(), other.getName());
-    }
   }
 
   @Test


### PR DESCRIPTION
Having Excerpts be reliably comparable with equality is extremely useful. Additionally, replace `SourceLevel.supportsDiamondOperator` with the more convenient `SourceLevel.diamondOperator`, which returns an Excerpt that uses the diamond operator when possible.