### PR TITLE
Don't output "T extends Object"

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
@@ -88,6 +88,10 @@ public abstract class GenericElement implements TypeElement {
       for (TypeMirror bound : bounds) {
         typeParameter.addBound(bound);
       }
+      if (bounds.length == 0) {
+        // In reality, there's always an "extends Object" floating around.
+        typeParameter.addBound(ClassTypeImpl.newTopLevelClass(Object.class.getName()));
+      }
       typeParameters.put(simpleName, typeParameter);
       return this;
     }


### PR DESCRIPTION
javac never returns an empty bound list, instead artificially putting Object in. Change GenericElement to match that behaviour, and fix ParameterizedType to pass tests again.

This fixes #179.