### PR TITLE
Speed up Circle builds threefold

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ shadowJar {
   exclude 'javax/annotation/meta/E*'
   exclude 'javax/annotation/meta/T*'
 }
+tasks.shadowJar.shouldRunAfter tasks.test
 
 import java.util.zip.ZipFile
 import java.util.zip.ZipException
@@ -150,7 +151,6 @@ task shadowTest {
   description 'Verifies freebuilder.jar is shaded correctly.'
   group = 'Verification'
   check.dependsOn it
-  shouldRunAfter test
   dependsOn shadowJar
   def expected = new File("$projectDir/jar-footprint.txt")
   def report = new File("$reportsDir/shadowJarFootprint.txt")
@@ -199,7 +199,6 @@ task vanillaTest {
   description 'Runs the vanilla integration tests.'
   group = 'Verification'
   check.dependsOn it
-  shouldRunAfter test
 }
 
 (6..8).each { jdk ->
@@ -326,7 +325,6 @@ task gwtTest(type: Test) {
   description 'Runs the GWT integration tests.'
   group = 'Verification'
   check.dependsOn it
-  shouldRunAfter test
   dependsOn compileGwtToJs
   testClassesDir = sourceSets.gwtTest.output.classesDir
   classpath = sourceSets.gwtTest.runtimeClasspath
@@ -358,7 +356,6 @@ task noGuavaTest {
   description 'Runs the no-guava integration tests.'
   group = 'Verification'
   check.dependsOn it
-  shouldRunAfter test
 }
 
 (6..8).each { jdk ->
@@ -442,7 +439,6 @@ task noGuavaJ8Test(type: Test) {
   description 'Runs the no-guava-j8 integration tests.'
   group = 'Verification'
   check.dependsOn it
-  shouldRunAfter test
   testClassesDir = sourceSets.noGuavaJ8Test.output.classesDir
   classpath = sourceSets.noGuavaJ8Test.runtimeClasspath
   reports {
@@ -489,7 +485,6 @@ task("lambdaTest", type: Test) {
   description 'Runs the lambda integration tests.'
   group = 'Verification'
   check.dependsOn it
-  shouldRunAfter test
   testClassesDir = sourceSets["lambdaTest"].output.classesDir
   classpath = sourceSets["lambdaTest"].runtimeClasspath
   reports {

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ String jackson(String pkg) {
       namespace, pkg, jacksonVersion)
 }
 
+test {
+  forkEvery = 5
+}
 tasks.withType(Test) {
   testLogging {
     events "passed", "skipped", "failed"

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
@@ -182,6 +182,7 @@ public class BehaviorTester {
    * @return a {@link CompilationSubject} with which to make further assertions
    */
   public CompilationSubject compiles() {
+    System.gc();
     try (TempJavaFileManager fileManager = new TempJavaFileManager()) {
       List<Diagnostic<? extends JavaFileObject>> diagnostics =
           compile(fileManager, compilationUnits, processors);

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
@@ -16,20 +16,18 @@
 package org.inferred.freebuilder.processor.util.testing;
 
 import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Iterables.filter;
 import static com.google.common.util.concurrent.Uninterruptibles.joinUninterruptibly;
-import static org.junit.Assert.fail;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
+import org.inferred.freebuilder.processor.util.testing.TestBuilder.TestSource;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +38,6 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
-import javax.tools.JavaFileObject.Kind;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
@@ -222,48 +219,21 @@ public class BehaviorTester {
   }
 
   private void runTests(final ClassLoader classLoader, final List<Throwable> throwables) {
-    for (Class<?> compiledClass : loadCompiledClasses(classLoader, compilationUnits)) {
-      for (Method testMethod : getTestMethods(compiledClass)) {
-        try {
-          testMethod.invoke(testMethod.getDeclaringClass().newInstance());
-        } catch (InvocationTargetException e) {
-          throwables.add(e.getCause());
-        } catch (IllegalAccessException | InstantiationException e) {
-          throwables.add(new AssertionError("Unexpected failure", e));
-        }
+    for (TestSource testSource : filter(compilationUnits, TestSource.class)) {
+      try {
+        Class<?> testClass = classLoader.loadClass(testSource.getClassName());
+        Object testInstance = testClass.newInstance();
+        Method testMethod = testClass.getMethod(testSource.getMethodName());
+        testMethod.invoke(testInstance);
+      } catch (InvocationTargetException e) {
+        throwables.add(e.getCause());
+      } catch (ClassNotFoundException
+          | NoSuchMethodException
+          | IllegalAccessException
+          | InstantiationException e) {
+        throwables.add(new AssertionError("Unexpected failure", e));
       }
     }
-  }
-
-  private static List<Class<?>> loadCompiledClasses(
-      ClassLoader classLoader, Iterable<? extends JavaFileObject> compilationUnits) {
-    try {
-      ImmutableList.Builder<Class<?>> resultBuilder = ImmutableList.builder();
-      for (JavaFileObject unit : compilationUnits) {
-        if (unit.getKind() == Kind.SOURCE) {
-          String typeName = SourceBuilder.getTypeNameFromSource(unit.getCharContent(true));
-          resultBuilder.add(classLoader.loadClass(typeName));
-        }
-      }
-      return resultBuilder.build();
-    } catch (IOException | ClassNotFoundException e) {
-      fail("Unexpected failure: " + e);
-      return null; // Unreachable
-    }
-  }
-
-  private static List<Method> getTestMethods(Class<?> cls) {
-    ImmutableList.Builder<Method> resultBuilder = ImmutableList.builder();
-    for (Method method : cls.getDeclaredMethods()) {
-      if (method.isAnnotationPresent(Test.class)) {
-        Preconditions.checkState(Modifier.isPublic(method.getModifiers()),
-            "Test %s#%s is not public", cls.getName(), method.getName());
-        Preconditions.checkState(method.getParameterTypes().length == 0,
-            "Test %s#%s has parameters", cls.getName(), method.getName());
-        resultBuilder.add(method);
-      }
-    }
-    return resultBuilder.build();
   }
 
   private static ImmutableList<Diagnostic<? extends JavaFileObject>> compile(

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/TestBuilder.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/TestBuilder.java
@@ -175,15 +175,16 @@ public class TestBuilder {
   /**
    * In-memory implementation of {@link javax.tools.JavaFileObject JavaFileObject} for test code.
    */
-  private static class TestSource extends SimpleJavaFileObject {
+  static class TestSource extends SimpleJavaFileObject {
 
-    @SuppressWarnings("unused")  // Prevents name from being reused prematurely
     private final UniqueName className;
+    private final String methodName;
     private final String source;
 
     private TestSource(UniqueName className, String methodName, String imports, String testCode) {
       super(SourceBuilder.uriForClass(className.getName()), Kind.SOURCE);
       this.className = className;
+      this.methodName = methodName;
       this.source = "package " + className.getNamespace() + "; "
           + "import static " + Assert.class.getName() + ".*; "
           + "import static " + Truth.class.getName() + ".assertThat; "
@@ -198,6 +199,14 @@ public class TestBuilder {
     @Override
     public CharSequence getCharContent(boolean ignoreEncodingErrors) {
       return source;
+    }
+
+    public String getClassName() {
+      return className.getName();
+    }
+
+    public String getMethodName() {
+      return methodName;
     }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/TestBuilderTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/TestBuilderTest.java
@@ -18,7 +18,12 @@ package org.inferred.freebuilder.processor.util.testing;
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.testing.SourceBuilder.getTypeNameFromSource;
 import static org.junit.Assert.assertEquals;
+import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
+import com.google.common.collect.LinkedHashMultiset;
+import com.google.common.collect.Multiset;
+
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,37 +34,32 @@ import javax.tools.JavaFileObject;
 
 /** Unit tests for {@link TestBuilder}. */
 @RunWith(JUnit4.class)
+@FixMethodOrder(NAME_ASCENDING)
 public class TestBuilderTest {
+
+  private final Multiset<String> seenNames = LinkedHashMultiset.create();
+
   @Test
-  public void testUniqueNames() throws IOException {
-    JavaFileObject source1 = new TestBuilder().build();
+  public void test1_UniqueNames() throws IOException {
+    JavaFileObject source1 = new TestBuilder().build().selectName(seenNames);
     assertEquals(
         "org.inferred.freebuilder.processor.util.testing.generatedcode.TestBuilderTest",
         getTypeNameFromSource(source1.getCharContent(false)));
-    JavaFileObject source2 = new TestBuilder().build();
+    JavaFileObject source2 = new TestBuilder().build().selectName(seenNames);
     assertEquals(
         "org.inferred.freebuilder.processor.util.testing.generatedcode.TestBuilderTest__2",
         getTypeNameFromSource(source2.getCharContent(false)));
-
-    source1 = null;
-
-    JavaFileObject source3 = new TestBuilder().build();
-    assertEquals(
-        "org.inferred.freebuilder.processor.util.testing.generatedcode.TestBuilderTest",
-        getTypeNameFromSource(source3.getCharContent(false)));
-    JavaFileObject source4 = new TestBuilder().build();
-    assertEquals(
-        "org.inferred.freebuilder.processor.util.testing.generatedcode.TestBuilderTest__3",
-        getTypeNameFromSource(source4.getCharContent(false)));
+    assertEquals(2, seenNames.size());
   }
 
   public static class InnerClass { }
 
   @Test
-  public void testInnerClassNames() throws IOException {
+  public void test2_InnerClassNames() throws IOException {
     String result = new TestBuilder()
         .addLine("%s", InnerClass.class)
         .build()
+        .selectName(seenNames)
         .getCharContent(false)
         .toString();
     assertThat(result).contains(


### PR DESCRIPTION
TestBuilder ensures test class names are unique, but attempts to reuse names across tests. The existing code did this via weakly retaining allocated names and avoiding collision, calling the garbage collector to free up names from old tests. It turns out this is INCREDIBLY costly, taking half the runtime of the test suite. BehaviorTester now stores the mutable data needed to ensure names are unique. This has reduced Circle execution time from ~20 minutes to ~7.