### PR TITLE
Pass -XDuseUnsharedTable into javac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,6 @@ String jackson(String pkg) {
       namespace, pkg, jacksonVersion)
 }
 
-test {
-  forkEvery = 5
-}
 tasks.withType(Test) {
   testLogging {
     events "passed", "skipped", "failed"

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
@@ -182,7 +182,6 @@ public class BehaviorTester {
    * @return a {@link CompilationSubject} with which to make further assertions
    */
   public CompilationSubject compiles() {
-    System.gc();
     try (TempJavaFileManager fileManager = new TempJavaFileManager()) {
       List<Diagnostic<? extends JavaFileObject>> diagnostics =
           compile(fileManager, compilationUnits, processors);
@@ -258,7 +257,7 @@ public class BehaviorTester {
         null,
         fileManager,
         diagnostics,
-        ImmutableList.of("-Xlint:unchecked", "-Xdiags:verbose"),
+        ImmutableList.of("-Xlint:unchecked", "-Xdiags:verbose", "-XDuseUnsharedTable"),
         null,
         compilationUnits);
     task.setProcessors(processors);

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/Model.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/Model.java
@@ -371,7 +371,7 @@ public class Model {
               null,  // Writer
               fileManager,
               diagnostics,
-              ImmutableList.of("-proc:only", "-encoding", "UTF-8"),
+              ImmutableList.of("-proc:only", "-encoding", "UTF-8", "-XDuseUnsharedTable"),
               null,  // Class names
               ImmutableList.of(bootstrapType));
           task.setProcessors(ImmutableList.of(new ElementCapturingProcessor()));

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/ModelTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/ModelTest.java
@@ -123,7 +123,7 @@ public class ModelTest {
   @Test
   public void newElementAnnotatedWith_noElementIdentified() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("no annotated element");
+    thrown.expectMessage("No element annotated with @java.lang.Deprecated found");
     model.newElementAnnotatedWith(
         Deprecated.class,
         "package foo.bar;",


### PR DESCRIPTION
The shared name tables javac keeps soft references to are causing severe memory pressure. This undocumented javac option disables them, allowing us to disable the `test.forkEvery` gradle option. (See also [this Gradle code](https://github.com/gradle/gradle/blob/master/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java#L93).) This PR also fixes a resource leak in Model.