### PR TITLE
Set max heap size for tests to 1GB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ String jackson(String pkg) {
 }
 
 test {
-  forkEvery = 5
+  maxHeapSize = "1024m"
 }
 tasks.withType(Test) {
   testLogging {


### PR DESCRIPTION
This seems to sort out the issues with Travis killing builds.