### PR TITLE
Fix bug with generic buildable properties

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildablePropertyFactory.java
@@ -207,10 +207,10 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code builder} is null")
           .addLine(" */")
-          .addLine("public %s %s(%s.Builder builder) {",
+          .addLine("public %s %s(%s builder) {",
               metadata.getBuilder(),
               setter(property),
-              property.getType())
+              builderType)
           .addLine("  return %s(builder.build());", setter(property))
           .addLine("}");
     }
@@ -232,11 +232,11 @@ public class BuildablePropertyFactory implements PropertyCodeGenerator.Factory {
           .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
           .addLine(" * @throws NullPointerException if {@code mutator} is null")
           .addLine(" */")
-          .addLine("public %s %s(%s<%s.Builder> mutator) {",
+          .addLine("public %s %s(%s<%s> mutator) {",
               metadata.getBuilder(),
               mutator(property),
               consumer.getQualifiedName(),
-              property.getType())
+              builderType)
           .addLine("  mutator.accept(%s);", property.getName())
           .addLine("  return (%s) this;", metadata.getBuilder())
           .addLine("}");

--- a/src/test/java/org/inferred/freebuilder/processor/BuildablePropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildablePropertyFactoryTest.java
@@ -797,6 +797,31 @@ public class BuildablePropertyFactoryTest {
   }
 
   @Test
+  public void testGenericChildProperty() {
+    // Raised in issue #183
+    behaviorTester
+        .with(new Processor())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface PIdentityDefinition<T, U> {")
+            .addLine("    class Builder<T, U> extends PIdentityDefinition_Builder<T, U> {}")
+            .addLine("}")
+            .build())
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface PAccess<T, U> {")
+            .addLine("    class Builder<T, U> extends PAccess_Builder<T, U> {}")
+            .addLine("")
+            .addLine("    PIdentityDefinition<T, U> getIdentity();")
+            .addLine("}")
+            .build())
+        .compiles()
+        .withNoWarnings();
+  }
+
+  @Test
   public void testIssue68_nameCollisionForValue() {
     // mergeFrom(DataType value) must resolve the name collision on "value"
     behaviorTester


### PR DESCRIPTION
Uncompilable code was being generated for generic buildable property types, due to mistakenly appending '.Builder' to the type rather than using the ParameterizedType `builderType`.

This fixes #183.