### PR TITLE
Test functionality against all feature sets

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
@@ -18,8 +18,8 @@ package org.inferred.freebuilder.processor.util;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.googlejavaformat.java.Formatter;
 
-import org.inferred.freebuilder.processor.util.feature.EnvironmentFeatureSet;
 import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.feature.FeatureType;
 
 import java.util.Collection;
@@ -37,13 +37,15 @@ public class CompilationUnitBuilder implements SourceBuilder {
   private final QualifiedName classToWrite;
 
   /**
-   * Returns a {@link CompilationUnitBuilder} for {@code classToWrite}. The file preamble (package
-   * and imports) will be generated automatically; the feature set will be taken from {@code env}..
+   * Returns a {@link CompilationUnitBuilder} for {@code classToWrite} using {@code features}. The
+   * file preamble (package and imports) will be generated automatically, and {@code env} will be
+   * inspected for potential import collisions.
    */
   public CompilationUnitBuilder(
       ProcessingEnvironment env,
       QualifiedName classToWrite,
-      Collection<QualifiedName> nestedClasses) {
+      Collection<QualifiedName> nestedClasses,
+      FeatureSet features) {
     this.classToWrite = classToWrite;
     // Write the source code into an intermediate SourceStringBuilder, as the imports need to be
     // written first, but aren't known yet.
@@ -57,7 +59,7 @@ public class CompilationUnitBuilder implements SourceBuilder {
       importManagerBuilder.addImplicitImport(nestedClass);
     }
     importManager = importManagerBuilder.build();
-    source = new SourceStringBuilder(importManager, new EnvironmentFeatureSet(env));
+    source = new SourceStringBuilder(importManager, features);
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/FunctionPackage.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/FunctionPackage.java
@@ -16,7 +16,7 @@ import javax.lang.model.util.Elements;
  */
 public enum FunctionPackage implements Feature<FunctionPackage> {
 
-  AVAILABLE, UNAVAILABLE;
+  AVAILABLE("Lambdas"), UNAVAILABLE("No lambdas");
 
   /**
    * Constant to pass to {@link SourceBuilder#feature(FeatureType)} to get the current status of
@@ -51,6 +51,12 @@ public enum FunctionPackage implements Feature<FunctionPackage> {
   private static final ParameterizedType UNARY_OPERATOR =
       QualifiedName.of("java.util.function", "UnaryOperator").withParameters("T");
 
+  private final String humanReadableFormat;
+
+  FunctionPackage(String humanReadableFormat) {
+    this.humanReadableFormat = humanReadableFormat;
+  }
+
   /**
    * Parameterized type for {@code java.util.function.Consumer<T>}, if available.
    */
@@ -70,6 +76,11 @@ public enum FunctionPackage implements Feature<FunctionPackage> {
    */
   public Optional<ParameterizedType> unaryOperator() {
     return ifAvailable(UNARY_OPERATOR);
+  }
+
+  @Override
+  public String toString() {
+    return humanReadableFormat;
   }
 
   private static boolean runningInEclipse() {

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/GuavaLibrary.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/GuavaLibrary.java
@@ -13,7 +13,7 @@ import javax.lang.model.element.TypeElement;
  */
 public enum GuavaLibrary implements Feature<GuavaLibrary> {
 
-  AVAILABLE, UNAVAILABLE;
+  AVAILABLE("Guava"), UNAVAILABLE("No Guava");
 
   /**
    * Constant to pass to {@link SourceBuilder#feature(FeatureType)} to get the current status of
@@ -34,7 +34,18 @@ public enum GuavaLibrary implements Feature<GuavaLibrary> {
     }
   };
 
+  private final String humanReadableFormat;
+
+  GuavaLibrary(String humanReadableFormat) {
+    this.humanReadableFormat = humanReadableFormat;
+  }
+
   public boolean isAvailable() {
     return this != UNAVAILABLE;
+  }
+
+  @Override
+  public String toString() {
+    return humanReadableFormat;
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
@@ -34,7 +34,7 @@ import javax.lang.model.SourceVersion;
  */
 public enum SourceLevel implements Feature<SourceLevel> {
 
-  JAVA_6, JAVA_7;
+  JAVA_6("Java 6"), JAVA_7("Java 7+");
 
   /**
    * Constant to pass to {@link SourceBuilder#feature(FeatureType)} to get the current
@@ -89,6 +89,12 @@ public enum SourceLevel implements Feature<SourceLevel> {
     }
   }
 
+  private final String humanReadableFormat;
+
+  SourceLevel(String humanReadableFormat) {
+    this.humanReadableFormat = humanReadableFormat;
+  }
+
   public Optional<QualifiedName> javaUtilObjects() {
     switch (this) {
       case JAVA_6:
@@ -97,5 +103,10 @@ public enum SourceLevel implements Feature<SourceLevel> {
       default:
         return Optional.of(QualifiedName.of("java.util", "Objects"));
     }
+  }
+
+  @Override
+  public String toString() {
+    return humanReadableFormat;
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/StaticFeatureSet.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/StaticFeatureSet.java
@@ -1,5 +1,6 @@
 package org.inferred.freebuilder.processor.util.feature;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -37,5 +38,10 @@ public class StaticFeatureSet implements FeatureSet {
       return feature;
     }
     return featureType.testDefault();
+  }
+
+  @Override
+  public String toString() {
+    return Joiner.on(", ").join(featuresByType.values());
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/BuildablePropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildablePropertyFactoryTest.java
@@ -15,29 +15,43 @@
  */
 package org.inferred.freebuilder.processor;
 
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
+import static org.junit.Assume.assumeTrue;
+
 import com.google.common.collect.ImmutableList;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class BuildablePropertyFactoryTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
 
   private static final JavaFileObject NO_DEFAULTS_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -206,6 +220,8 @@ public class BuildablePropertyFactoryTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
@@ -213,7 +229,7 @@ public class BuildablePropertyFactoryTest {
   public void testBuild_noDefaults() {
     thrown.expect(IllegalStateException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().build();")
@@ -224,7 +240,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testBuild_defaults() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -239,7 +255,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testBuildPartial() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -253,7 +269,7 @@ public class BuildablePropertyFactoryTest {
   public void testBuildPartialAndGet() {
     thrown.expect(UnsupportedOperationException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -267,7 +283,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -291,7 +307,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToValue_nestedList() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NESTED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -312,7 +328,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToValue_protolike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PROTOLIKE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -333,7 +349,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToValue_freebuilderlike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(FREEBUILDERLIKE_TYPE)
         .with(FREEBUILDERLIKE_BUILDER_SUPERCLASS)
         .with(new TestBuilder()
@@ -355,7 +371,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToBuilder_valuesSet() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -377,7 +393,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToBuilder_nestedList() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NESTED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -396,7 +412,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToBuilder_protolike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PROTOLIKE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -415,7 +431,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testSetToBuilder_freebuilderlike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(FREEBUILDERLIKE_TYPE)
         .with(FREEBUILDERLIKE_BUILDER_SUPERCLASS)
         .with(new TestBuilder()
@@ -436,7 +452,7 @@ public class BuildablePropertyFactoryTest {
   public void testSetToBuilder_missingValue() {
     thrown.expect(IllegalStateException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -448,8 +464,9 @@ public class BuildablePropertyFactoryTest {
 
   @Test
   public void testMutateMethod() {
+    assumeTrue("Environment has lambdas", features.get(FUNCTION_PACKAGE).consumer().isPresent());
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -471,7 +488,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testGetBuilder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -484,7 +501,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testGetBuilder_protolike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PROTOLIKE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -497,7 +514,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testGetBuilder_freebuilderlike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(FREEBUILDERLIKE_TYPE)
         .with(FREEBUILDERLIKE_BUILDER_SUPERCLASS)
         .with(new TestBuilder()
@@ -511,7 +528,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testMergeFromBuilder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder()")
@@ -543,7 +560,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testMergeFromBuilder_nestedList() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NESTED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -565,7 +582,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testMergeFromBuilder_protolike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PROTOLIKE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -587,7 +604,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testMergeFromBuilder_freebuilderlike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(FREEBUILDERLIKE_TYPE)
         .with(FREEBUILDERLIKE_BUILDER_SUPERCLASS)
         .with(new TestBuilder()
@@ -610,7 +627,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testMergeFromValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder()")
@@ -647,7 +664,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testMergeFromValue_nestedList() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NESTED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -670,7 +687,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testMergeFromValue_protolike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PROTOLIKE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -693,7 +710,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_DEFAULTS_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder()")
@@ -730,7 +747,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testBuilderClear_nestedList() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NESTED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -753,7 +770,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testBuilderClear_protolike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PROTOLIKE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -776,7 +793,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void testBuilderClear_freebuilderlike() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(FREEBUILDERLIKE_TYPE)
         .with(FREEBUILDERLIKE_BUILDER_SUPERCLASS)
         .with(new TestBuilder()
@@ -826,7 +843,7 @@ public class BuildablePropertyFactoryTest {
   public void testIssue68_nameCollisionForValue() {
     // mergeFrom(DataType value) must resolve the name collision on "value"
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -874,7 +891,7 @@ public class BuildablePropertyFactoryTest {
   public void testIssue68_nameCollisionForTemplate() {
     // mergeFrom(DataType.Template template) must resolve the name collision on "template"
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -922,7 +939,7 @@ public class BuildablePropertyFactoryTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")
@@ -970,7 +987,7 @@ public class BuildablePropertyFactoryTest {
   @Test
   public void hiddenBuilderNotIllegallyReferenced() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example.foo;")
             .addLine("public abstract class Item {")

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultMapperMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultMapperMethodTest.java
@@ -18,20 +18,33 @@ package org.inferred.freebuilder.processor;
 import com.google.common.base.Preconditions;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class DefaultMapperMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_LAMBDAS;
+  }
 
   private static final JavaFileObject REQUIRED_INTEGER_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -57,13 +70,15 @@ public class DefaultMapperMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void mapReplacesValueToBeReturnedFromGetterForRequiredProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -78,7 +93,7 @@ public class DefaultMapperMethodTest {
   @Test
   public void mapReplacesValueToBeReturnedFromGetterForDefaultProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(DEFAULT_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -94,7 +109,7 @@ public class DefaultMapperMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("property must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -123,7 +138,7 @@ public class DefaultMapperMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("property must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -154,7 +169,7 @@ public class DefaultMapperMethodTest {
   public void mapThrowsNpeIfMapperIsNullForRequiredProperty() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -168,7 +183,7 @@ public class DefaultMapperMethodTest {
   public void mapThrowsNpeIfMapperIsNullForDefaultProperty() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(DEFAULT_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -181,7 +196,7 @@ public class DefaultMapperMethodTest {
   public void mapThrowsNpeIfMapperIsNullForUnsetRequiredProperty() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -194,7 +209,7 @@ public class DefaultMapperMethodTest {
   public void mapThrowsNpeIfMapperReturnsNullForRequiredProperty() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -208,7 +223,7 @@ public class DefaultMapperMethodTest {
   public void mapThrowsNpeIfMapperReturnsNullForDefaultProperty() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(DEFAULT_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -222,7 +237,7 @@ public class DefaultMapperMethodTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("property not set");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesTest.java
@@ -16,8 +16,10 @@
 package org.inferred.freebuilder.processor;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
 import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
@@ -32,15 +34,22 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import java.util.List;
+
 import javax.tools.JavaFileObject;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class DefaultedPropertiesTest {
 
-  @Parameters(name = "{0}")
-  public static Iterable<JavaFileObject> parameters() {
-    return ImmutableList.of(OPTIMIZED_BUILDER, SLOW_BUILDER);
+  @Parameters(name = "{0}, {1}")
+  @SuppressWarnings("unchecked")
+  public static Iterable<Object[]> featureSets() {
+    return () -> Lists
+        .cartesianProduct(FeatureSets.ALL, ImmutableList.of(OPTIMIZED_BUILDER, SLOW_BUILDER))
+        .stream()
+        .map(List::toArray)
+        .iterator();
   }
 
   /**
@@ -86,14 +95,14 @@ public class DefaultedPropertiesTest {
       .build();
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
-
   @Shared public BehaviorTester behaviorTester;
-  @Parameter public JavaFileObject dataType;
+  @Parameter(value = 0) public FeatureSet features;
+  @Parameter(value = 1) public JavaFileObject dataType;
 
   @Test
   public void testMergeFromBuilder_defaultsDoNotOverride() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -110,7 +119,7 @@ public class DefaultedPropertiesTest {
   @Test
   public void testMergeFromValue_defaultsDoNotOverride() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -127,7 +136,7 @@ public class DefaultedPropertiesTest {
   @Test
   public void testMergeFromBuilder_nonDefaultsUsed() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -144,7 +153,7 @@ public class DefaultedPropertiesTest {
   @Test
   public void testMergeFromValue_nonDefaultsUsed() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -162,7 +171,7 @@ public class DefaultedPropertiesTest {
   @Test
   public void testMergeFromBuilder_nonDefaultsOverride() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -180,7 +189,7 @@ public class DefaultedPropertiesTest {
   @Test
   public void testMergeFromValue_nonDefaultsOverride() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -199,7 +208,7 @@ public class DefaultedPropertiesTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/FeatureSets.java
+++ b/src/test/java/org/inferred/freebuilder/processor/FeatureSets.java
@@ -1,0 +1,42 @@
+package org.inferred.freebuilder.processor;
+
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_6;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
+import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
+import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
+
+import java.util.List;
+
+final class FeatureSets {
+
+  /** For tests valid in any environment. */
+  public static final List<FeatureSet> ALL = ImmutableList.of(
+      new StaticFeatureSet(JAVA_6),
+      new StaticFeatureSet(JAVA_7),
+      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE),
+      new StaticFeatureSet(JAVA_6, GuavaLibrary.AVAILABLE),
+      new StaticFeatureSet(JAVA_7, GuavaLibrary.AVAILABLE),
+      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+
+  /** For mapper and mutate method tests. */
+  public static final List<FeatureSet> WITH_LAMBDAS = ImmutableList.of(
+      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE),
+      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+
+  /** For tests using Guava types. */
+  public static final List<FeatureSet> WITH_GUAVA = ImmutableList.of(
+      new StaticFeatureSet(JAVA_6, GuavaLibrary.AVAILABLE),
+      new StaticFeatureSet(JAVA_7, GuavaLibrary.AVAILABLE),
+      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+
+  /** For mutate method tests using Guava types. */
+  public static final List<FeatureSet> WITH_GUAVA_AND_LAMBDAS = ImmutableList.of(
+      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+
+  private FeatureSets() {}
+}

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeTest.java
@@ -16,23 +16,38 @@
 package org.inferred.freebuilder.processor;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-@RunWith(BehaviorTestRunner.class)
+import java.util.List;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class GenericTypeTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
+
+  @Parameter public FeatureSet features;
 
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testGenericInterface() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -58,7 +73,7 @@ public class GenericTypeTest {
   @Test
   public void testGenericInterface_compilesWithoutWarnings() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -76,7 +91,7 @@ public class GenericTypeTest {
   @Test
   public void testBoundedParameters() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalPropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalPropertyTest.java
@@ -25,21 +25,34 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
 /** Behavioral tests for {@code Optional<?>} properties. */
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class GuavaOptionalPropertyTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_GUAVA;
+  }
 
   private static final JavaFileObject TWO_OPTIONAL_PROPERTIES_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -81,13 +94,15 @@ public class GuavaOptionalPropertyTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testConstructor_defaultAbsent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -99,7 +114,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testConstructor_primitive_defaultAbsent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -111,7 +126,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testBuilderGetter_defaultValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -123,7 +138,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testBuilderGetter_nonDefaultValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder()")
@@ -136,7 +151,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSet_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -151,7 +166,7 @@ public class GuavaOptionalPropertyTest {
   public void testSet_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((String) null);")
@@ -162,7 +177,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSet_optionalOf() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -176,7 +191,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSet_absent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -191,7 +206,7 @@ public class GuavaOptionalPropertyTest {
   public void testSet_nullOptional() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((%s<String>) null);",
@@ -203,7 +218,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSetNullable_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -217,7 +232,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSetNullable_null() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -231,7 +246,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -246,7 +261,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSet_primitive_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -261,7 +276,7 @@ public class GuavaOptionalPropertyTest {
   public void testSet_primitive_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((Integer) null);")
@@ -272,7 +287,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSet_primitive_optionalOf() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -286,7 +301,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSet_primitive_absent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -301,7 +316,7 @@ public class GuavaOptionalPropertyTest {
   public void testSet_primitive_nullOptional() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((%s<Integer>) null);",
@@ -313,7 +328,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSetNullable_primitive_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -327,7 +342,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testSetNullable_primitive_null() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -341,7 +356,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testClear_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -356,7 +371,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -372,7 +387,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder template = com.example.DataType.builder()")
@@ -387,7 +402,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testMergeFrom_valueInstance_emptyOptional() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -403,7 +418,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testMergeFrom_builder_emptyOptional() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder template = com.example.DataType.builder();")
@@ -418,7 +433,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -433,7 +448,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testBuilderClear_customDefault() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -459,7 +474,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testBuilderClear_noBuilderFactory() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -487,7 +502,7 @@ public class GuavaOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too long");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -519,7 +534,7 @@ public class GuavaOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too long");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -550,7 +565,7 @@ public class GuavaOptionalPropertyTest {
   public void testCustomization_absent() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -579,7 +594,7 @@ public class GuavaOptionalPropertyTest {
   public void testCustomization_null() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -609,7 +624,7 @@ public class GuavaOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too big");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -640,7 +655,7 @@ public class GuavaOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too big");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -670,7 +685,7 @@ public class GuavaOptionalPropertyTest {
   public void testCustomization_primitive_absent() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -699,7 +714,7 @@ public class GuavaOptionalPropertyTest {
   public void testCustomization_primitive_null() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -727,7 +742,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -754,7 +769,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testValueToString_singleField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType absent = com.example.DataType.builder()")
@@ -771,7 +786,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testValueToString_twoFields() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_OPTIONAL_PROPERTIES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType aa = com.example.DataType.builder()")
@@ -797,7 +812,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testPartialToString_singleField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType absent = com.example.DataType.builder()")
@@ -814,7 +829,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testPartialToString_twoFields() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_OPTIONAL_PROPERTIES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType aa = com.example.DataType.builder()")
@@ -840,7 +855,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testWildcardHandling_noWildcard() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
               .addLine("package com.example;")
               .addLine("@%s", FreeBuilder.class)
@@ -862,7 +877,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testWildcardHandling_unboundedWildcard() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
               .addLine("package com.example;")
               .addLine("@%s", FreeBuilder.class)
@@ -884,7 +899,7 @@ public class GuavaOptionalPropertyTest {
   @Test
   public void testWildcardHandling_wildcardWithExtendsBound() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
               .addLine("package com.example;")
               .addLine("@%s", FreeBuilder.class)
@@ -907,7 +922,7 @@ public class GuavaOptionalPropertyTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalPropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalPropertyTest.java
@@ -24,23 +24,35 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.tools.JavaFileObject;
 
 /** Behavioral tests for {@code Optional<?>} properties. */
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class JavaUtilOptionalPropertyTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_LAMBDAS;
+  }
 
   private static final JavaFileObject TWO_OPTIONAL_PROPERTIES_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -82,13 +94,15 @@ public class JavaUtilOptionalPropertyTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testConstructor_defaultEmpty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -100,7 +114,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testConstructor_primitive_defaultEmpty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -112,7 +126,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testBuilderGetter_defaultValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -124,7 +138,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testBuilderGetter_nonDefaultValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder()")
@@ -137,7 +151,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSet_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -152,7 +166,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testSet_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((String) null);")
@@ -163,7 +177,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSet_optionalOf() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -177,7 +191,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSet_empty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -192,7 +206,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testSet_nullOptional() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((%s<String>) null);",
@@ -204,7 +218,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSetNullable_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -218,7 +232,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSetNullable_null() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -232,7 +246,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -247,7 +261,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSet_primitive_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -262,7 +276,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testSet_primitive_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((Integer) null);")
@@ -273,7 +287,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSet_primitive_optionalOf() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -287,7 +301,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSet_primitive_empty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -302,7 +316,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testSet_primitive_nullOptional() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().setItem((%s<Integer>) null);",
@@ -314,7 +328,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSetNullable_primitive_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -328,7 +342,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testSetNullable_primitive_null() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -342,7 +356,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testClear_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -357,7 +371,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -373,7 +387,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder template = com.example.DataType.builder()")
@@ -388,7 +402,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testMergeFrom_valueInstance_emptyOptional() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -404,7 +418,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testMergeFrom_builder_emptyOptional() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder template = com.example.DataType.builder();")
@@ -419,7 +433,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -434,7 +448,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testBuilderClear_customDefault() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -460,7 +474,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testBuilderClear_noBuilderFactory() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -488,7 +502,7 @@ public class JavaUtilOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too long");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -520,7 +534,7 @@ public class JavaUtilOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too long");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -551,7 +565,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testCustomization_empty() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -580,7 +594,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testCustomization_null() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -610,7 +624,7 @@ public class JavaUtilOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too big");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -641,7 +655,7 @@ public class JavaUtilOptionalPropertyTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Item too big");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -671,7 +685,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testCustomization_primitive_empty() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -700,7 +714,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testCustomization_primitive_null() {
     thrown.expectMessage("Fooled you!");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -728,7 +742,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -755,7 +769,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testValueToString_singleField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType empty = com.example.DataType.builder()")
@@ -772,7 +786,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testValueToString_twoFields() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_OPTIONAL_PROPERTIES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType aa = com.example.DataType.builder()")
@@ -798,7 +812,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testPartialToString_singleField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(OPTIONAL_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType empty = com.example.DataType.builder()")
@@ -815,7 +829,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testPartialToString_twoFields() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_OPTIONAL_PROPERTIES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType aa = com.example.DataType.builder()")
@@ -841,7 +855,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testWildcardHandling_noWildcard() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
               .addLine("package com.example;")
               .addLine("@%s", FreeBuilder.class)
@@ -863,7 +877,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testWildcardHandling_unboundedWildcard() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
               .addLine("package com.example;")
               .addLine("@%s", FreeBuilder.class)
@@ -885,7 +899,7 @@ public class JavaUtilOptionalPropertyTest {
   @Test
   public void testWildcardHandling_wildcardWithExtendsBound() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
               .addLine("package com.example;")
               .addLine("@%s", FreeBuilder.class)
@@ -908,7 +922,7 @@ public class JavaUtilOptionalPropertyTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")

--- a/src/test/java/org/inferred/freebuilder/processor/ListMultimapMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMultimapMutateMethodTest.java
@@ -22,22 +22,34 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class ListMultimapMutateMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_GUAVA_AND_LAMBDAS;
+  }
 
   private static final JavaFileObject UNCHECKED_PROPERTY = new SourceBuilder()
       .addLine("package com.example;")
@@ -81,13 +93,15 @@ public class ListMultimapMutateMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void mutateAndPutModifiesUnderlyingProperty_whenUnchecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(UNCHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -108,7 +122,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndPutModifiesUnderlyingProperty_whenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -131,7 +145,7 @@ public class ListMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items.put(\"one\", \"\"));")
@@ -142,7 +156,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndPutKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -159,7 +173,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllValuesModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -182,7 +196,7 @@ public class ListMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items")
@@ -194,7 +208,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllValuesKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -212,7 +226,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllMultimapModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -233,7 +247,7 @@ public class ListMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items")
@@ -245,7 +259,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllMultimapKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -263,7 +277,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndReplaceValuesModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -284,7 +298,7 @@ public class ListMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -298,7 +312,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndReplaceValuesKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -317,7 +331,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaGetModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -337,7 +351,7 @@ public class ListMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -350,7 +364,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaGetKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -370,7 +384,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaAsMapModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -390,7 +404,7 @@ public class ListMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -403,7 +417,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaAsMapKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -421,7 +435,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndAddAtIndexViaAsMapModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -442,7 +456,7 @@ public class ListMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -456,7 +470,7 @@ public class ListMultimapMutateMethodTest {
   @Test
   public void mutateAndAddAtIndexViaAsMapKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")

--- a/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMultimapPropertyFactoryTest.java
@@ -30,22 +30,34 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class ListMultimapPropertyFactoryTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_GUAVA;
+  }
 
   private static final JavaFileObject MULTIMAP_PROPERTY = new SourceBuilder()
       .addLine("package com.example;")
@@ -99,13 +111,15 @@ public class ListMultimapPropertyFactoryTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testDefaultEmpty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder().build();")
@@ -118,7 +132,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testDefaultEmpty_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder().build();")
@@ -131,7 +145,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPut() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -150,7 +164,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPut_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -169,7 +183,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPut_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -188,7 +202,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPut_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -208,7 +222,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testPut_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -222,7 +236,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testPut_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -235,7 +249,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPut_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -256,7 +270,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -276,7 +290,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -296,7 +310,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -316,7 +330,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -337,7 +351,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testPutAllIterable_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -350,7 +364,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testPutAllIterable_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -362,7 +376,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -380,7 +394,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_iteratesOnce() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -416,7 +430,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -438,7 +452,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -460,7 +474,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -482,7 +496,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -505,7 +519,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testPutAllMultimap_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("%1$s<String, String> values = %1$s.create();", LinkedListMultimap.class)
@@ -519,7 +533,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testPutAllMultimap_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("%1$s<String, String> values = %1$s.create();", LinkedListMultimap.class)
@@ -532,7 +546,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -554,7 +568,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemove() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -576,7 +590,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemove_doesNotThrowIfEntryNotPresent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -597,7 +611,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemove_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -619,7 +633,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemove_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -641,7 +655,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemove_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -664,7 +678,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testRemove_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -678,7 +692,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testRemove_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -691,7 +705,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -711,7 +725,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_doesNotThrowIfKeyNotPresent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -729,7 +743,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -749,7 +763,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -769,7 +783,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -790,7 +804,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testRemoveAll_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -803,7 +817,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -824,7 +838,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testGet_returnsLiveView() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType.Builder builder = new DataType.Builder();")
@@ -844,7 +858,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testGet_returnsUnmodifiableMultimap() {
     thrown.expect(UnsupportedOperationException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType.Builder builder = new DataType.Builder();")
@@ -857,7 +871,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = DataType.builder()")
@@ -878,7 +892,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType.Builder template = DataType.builder()")
@@ -898,7 +912,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -933,7 +947,7 @@ public class ListMultimapPropertyFactoryTest {
 
   private void testPropertyOfMultimapSubclassType(Class<?> propertyType) {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -963,7 +977,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -994,7 +1008,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -1025,7 +1039,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -1056,7 +1070,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -1087,7 +1101,7 @@ public class ListMultimapPropertyFactoryTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -1122,7 +1136,7 @@ public class ListMultimapPropertyFactoryTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")

--- a/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
@@ -18,22 +18,33 @@ package org.inferred.freebuilder.processor;
 import com.google.common.base.Preconditions;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class ListMutateMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_LAMBDAS;
+  }
 
   private static final JavaFileObject UNCHECKED_LIST_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -76,13 +87,15 @@ public class ListMutateMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void mutateAndAddModifiesUnderlyingPropertyWhenUnchecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(UNCHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -96,7 +109,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndAddModifiesUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -112,7 +125,7 @@ public class ListMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().mutateProperties(map -> map.add(-3));")
@@ -123,7 +136,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndAddKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_STRINGS_TYPE)
         .with(new TestBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -140,7 +153,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndAddAtIndex0ModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -155,7 +168,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndAddAtIndex1ModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -170,7 +183,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndAddAtIndex2ModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -185,7 +198,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndAddAtIndex3ModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -202,7 +215,7 @@ public class ListMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -215,7 +228,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndAddAtIndexKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_STRINGS_TYPE)
         .with(new TestBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -233,7 +246,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndSetModifiesUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -250,7 +263,7 @@ public class ListMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -263,7 +276,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndSetAtIndexKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_STRINGS_TYPE)
         .with(new TestBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -281,7 +294,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndSizeReadsFromUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -294,7 +307,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndGetReadsFromUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -307,7 +320,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndRemoveModifiesUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -322,7 +335,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndClearModifiesUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -338,7 +351,7 @@ public class ListMutateMethodTest {
   @Test
   public void mutateAndClearSubListModifiesUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_LIST_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/ListPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListPropertyFactoryTest.java
@@ -15,6 +15,9 @@
  */
 package org.inferred.freebuilder.processor;
 
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.junit.Assume.assumeTrue;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 
@@ -22,15 +25,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
 import java.util.List;
@@ -38,8 +46,14 @@ import java.util.List;
 import javax.tools.JavaFileObject;
 
 /** Behavioral tests for {@code List<?>} properties. */
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class ListPropertyFactoryTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
 
   private static final JavaFileObject LIST_PROPERTY_AUTO_BUILT_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -54,13 +68,15 @@ public class ListPropertyFactoryTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testDefaultEmpty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder().build();")
@@ -72,7 +88,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testAddSingleElement() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -88,7 +104,7 @@ public class ListPropertyFactoryTest {
   public void testAddSingleElement_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -100,7 +116,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testAddVarargs() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -115,7 +131,7 @@ public class ListPropertyFactoryTest {
   public void testAddVarargs_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -127,7 +143,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testAddAllIterable() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -141,7 +157,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testAddAllIterable_onlyIteratesOnce() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -173,7 +189,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -189,7 +205,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testGetter_returnsLiveView() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType.Builder builder = new DataType.Builder();")
@@ -209,7 +225,7 @@ public class ListPropertyFactoryTest {
   public void testGetter_returnsUnmodifiableList() {
     thrown.expect(UnsupportedOperationException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType.Builder builder = new DataType.Builder();")
@@ -222,7 +238,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = DataType.builder()")
@@ -238,7 +254,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType.Builder template = DataType.builder()")
@@ -253,7 +269,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -269,7 +285,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testBuilderClear_noBuilderFactory() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -297,7 +313,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
         .with(testBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -325,8 +341,9 @@ public class ListPropertyFactoryTest {
 
   @Test
   public void testImmutableListProperty() {
+    assumeTrue("Guava available", features.get(GUAVA).isAvailable());
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -349,7 +366,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testOverrideAdd() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -377,7 +394,7 @@ public class ListPropertyFactoryTest {
   @Test
   public void testOverrideAdd_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -406,7 +423,7 @@ public class ListPropertyFactoryTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")

--- a/src/test/java/org/inferred/freebuilder/processor/MapMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapMutateMethodTest.java
@@ -19,23 +19,35 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class MapMutateMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_LAMBDAS;
+  }
 
   private static final JavaFileObject UNCHECKED_SET_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -64,13 +76,15 @@ public class MapMutateMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void putModifiesUnderlyingPropertyWhenUnchecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(UNCHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -88,7 +102,7 @@ public class MapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("key must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -100,7 +114,7 @@ public class MapMutateMethodTest {
   @Test
   public void putModifiesUnderlyingPropertyWhenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -116,7 +130,7 @@ public class MapMutateMethodTest {
   @Test
   public void iterateEntrySetFindsContainedEntry() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -134,7 +148,7 @@ public class MapMutateMethodTest {
   @Test
   public void callRemoveOnEntrySetIteratorModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -156,7 +170,7 @@ public class MapMutateMethodTest {
   @Test
   public void entrySetIteratorRemainsUsableAfterCallingRemove() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -185,7 +199,7 @@ public class MapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value must not start with '-'");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -199,7 +213,7 @@ public class MapMutateMethodTest {
   @Test
   public void callSetValueOnEntryModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -216,7 +230,7 @@ public class MapMutateMethodTest {
   @Test
   public void entryRemainsUsableAfterCallingSetValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -239,7 +253,7 @@ public class MapMutateMethodTest {
   @Test
   public void entrySetIteratorRemainsUsableAfterCallingSetValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -265,7 +279,7 @@ public class MapMutateMethodTest {
   @Test
   public void getReturnsContainedValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -279,7 +293,7 @@ public class MapMutateMethodTest {
   @Test
   public void containsKeyFindsContainedKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -293,7 +307,7 @@ public class MapMutateMethodTest {
   @Test
   public void removeModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -310,7 +324,7 @@ public class MapMutateMethodTest {
   @Test
   public void clearModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/MapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapPropertyFactoryTest.java
@@ -15,6 +15,9 @@
  */
 package org.inferred.freebuilder.processor;
 
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.junit.Assume.assumeTrue;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 
@@ -22,24 +25,36 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.tools.JavaFileObject;
 
 /** Behavioral tests for {@code List<?>} properties. */
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class MapPropertyFactoryTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
 
   private static final JavaFileObject MAP_PROPERTY_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -81,13 +96,15 @@ public class MapPropertyFactoryTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testDefaultEmpty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -99,7 +116,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testPut_nonNullKey_nonNullValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -116,7 +133,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testPut_primitiveKey_nonNullValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PRIMITIVE_KEY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -133,7 +150,7 @@ public class MapPropertyFactoryTest {
   public void testPut_nullKey_nonNullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -145,7 +162,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testPut_nonNullKey_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PRIMITIVE_VALUE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -161,7 +178,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testPut_primitiveKey_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PRIMITIVE_KEY_VALUE_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -178,7 +195,7 @@ public class MapPropertyFactoryTest {
   public void testPut_nullKey_primitiveValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PRIMITIVE_VALUE_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -191,7 +208,7 @@ public class MapPropertyFactoryTest {
   public void testPut_nonNullKey_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -204,7 +221,7 @@ public class MapPropertyFactoryTest {
   public void testPut_primitiveKey_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PRIMITIVE_KEY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -216,7 +233,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testPut_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -232,7 +249,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testPutAll_noNulls() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -250,7 +267,7 @@ public class MapPropertyFactoryTest {
   public void testPutAll_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("%s<String, Object> items = new %s<String, Object>();",
@@ -267,7 +284,7 @@ public class MapPropertyFactoryTest {
   public void testPutAll_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("%s<String, Object> items = new %s<String, Object>();",
@@ -283,7 +300,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testPutAll_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -300,7 +317,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testRemove() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -320,7 +337,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testRemove_missingKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -337,7 +354,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testRemove_primitiveKeyType() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PRIMITIVE_KEY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -357,7 +374,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testRemove_primitiveKeyType_missingKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(PRIMITIVE_KEY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -375,7 +392,7 @@ public class MapPropertyFactoryTest {
   public void testRemove_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -389,7 +406,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -409,7 +426,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testGet_returnsLiveView() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -433,7 +450,7 @@ public class MapPropertyFactoryTest {
   public void testGet_returnsUnmodifiableMap() {
     thrown.expect(UnsupportedOperationException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -446,7 +463,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType template = new com.example.DataType.Builder()")
@@ -466,7 +483,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder template = new com.example.DataType.Builder()")
@@ -485,7 +502,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -505,7 +522,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testBuilderClear_noDefaultFactory() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -536,8 +553,9 @@ public class MapPropertyFactoryTest {
 
   @Test
   public void testImmutableMapProperty() {
+    assumeTrue("Guava available", features.get(GUAVA).isAvailable());
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -562,7 +580,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testOverridingAdd() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -591,7 +609,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testOverridingAdd_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -620,7 +638,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testOverridingAdd_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -649,7 +667,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testOverridingAdd_primitiveKeyAndValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -678,7 +696,7 @@ public class MapPropertyFactoryTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MAP_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -710,7 +728,7 @@ public class MapPropertyFactoryTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")

--- a/src/test/java/org/inferred/freebuilder/processor/MultisetMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MultisetMutateMethodTest.java
@@ -21,20 +21,33 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class MultisetMutateMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_GUAVA_AND_LAMBDAS;
+  }
 
   private static final JavaFileObject UNCHECKED_PROPERTY = new SourceBuilder()
       .addLine("package com.example;")
@@ -76,13 +89,15 @@ public class MultisetMutateMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void mutateAndAddModifiesUnderlyingProperty_whenUnchecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(UNCHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -97,7 +112,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddModifiesUnderlyingProperty_whenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -114,7 +129,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -127,7 +142,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddAcceptsMaxIntOccurrences() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -144,7 +159,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("too many occurrences: 2147483648");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -157,7 +172,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -174,7 +189,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddMultipleModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -191,7 +206,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("occurrences cannot be negative: -2");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -204,7 +219,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddMultipleAcceptsMaxIntOccurrences() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -221,7 +236,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("too many occurrences: 2147483648");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -234,7 +249,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddMultipleReturnsOldCount() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -249,7 +264,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -262,7 +277,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddMultipleKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -279,7 +294,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndSetCountModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -294,7 +309,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndSetCountReturnsOldCount() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -309,7 +324,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -324,7 +339,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("count cannot be negative but was: -3");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -337,7 +352,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndSetCountKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -354,7 +369,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndConditionallySetCountModifiesUnderlyingPropertyIfOldCountMatches() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -369,7 +384,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndConditionallySetCountDoesNothingIfOldCountDoesNotMatch() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -384,7 +399,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndConditionallySetCountReturnsTrueIfOldCountMatches() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -397,7 +412,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndConditionallySetCountReturnsFalseIfOldCountDoesNotMatch() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -412,7 +427,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -427,7 +442,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("newCount cannot be negative but was: -3");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -440,7 +455,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndConditionallySetCountKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -457,7 +472,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddAllModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -474,7 +489,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -487,7 +502,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddAllAcceptsMaxIntOccurrences() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -504,7 +519,7 @@ public class MultisetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("too many occurrences: 2147483648");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -517,7 +532,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndAddAllKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -534,7 +549,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndSizeReturnsSize() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -547,7 +562,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndContainsReturnsTrueForContainedElement() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -560,7 +575,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndIterateFindsContainedElement() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -576,7 +591,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndRemoveModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -591,7 +606,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndCallRemoveOnIteratorModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -613,7 +628,7 @@ public class MultisetMutateMethodTest {
   @Test
   public void mutateAndClearModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/MultisetPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MultisetPropertyFactoryTest.java
@@ -25,9 +25,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.CompilationException;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
@@ -35,13 +36,24 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class MultisetPropertyFactoryTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
 
   private static final JavaFileObject MULTISET_PROPERTY_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -69,13 +81,15 @@ public class MultisetPropertyFactoryTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testDefaultEmpty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -87,7 +101,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddSingleElement() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -103,7 +117,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddSingleElement_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -116,7 +130,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddSingleElement_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -131,7 +145,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddVarargs() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -146,7 +160,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddVarargs_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().addItems(\"one\", null);")
@@ -157,7 +171,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddVarargs_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
         .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -171,7 +185,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddAllIterable() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -186,7 +200,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddAllIterable_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -198,7 +212,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddAllIterable_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -212,7 +226,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddAllIterable_iteratesOnce() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -244,7 +258,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddCopies() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -261,7 +275,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddCopies_null() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -275,7 +289,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddCopies_negativeOccurrences() {
     thrown.expect(IllegalArgumentException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -288,7 +302,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddCopies_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -304,7 +318,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testSetCountOf() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -321,7 +335,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testSetCountOf_toZero() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -337,7 +351,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -353,7 +367,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testDefaultEmpty_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -365,7 +379,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddSingleElement_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -381,7 +395,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddSingleElement_null_primitive() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -394,7 +408,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddSingleElement_duplicate_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -409,7 +423,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddVarargs_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -423,7 +437,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddVarargs_null_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().addItems(1, null);")
@@ -435,7 +449,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddVarargs_duplicate_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
         .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -449,7 +463,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddAllIterable_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -464,7 +478,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddAllIterable_null_primitive() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -476,7 +490,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddAllIterable_duplicate_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -490,7 +504,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddCopies_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -506,7 +520,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddCopies_null_primitive() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -520,7 +534,7 @@ public class MultisetPropertyFactoryTest {
   public void testAddCopies_negativeOccurrences_primitive() {
     thrown.expect(IllegalArgumentException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -533,7 +547,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testAddCopies_duplicate_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -548,7 +562,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testSetCountOf_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -564,7 +578,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testSetCountOf_toZero_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -580,7 +594,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testClear_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PRIMITIVES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -596,7 +610,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testGet_returnsLiveView() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -616,7 +630,7 @@ public class MultisetPropertyFactoryTest {
   public void testGet_returnsUnmodifiableSet() {
     thrown.expect(UnsupportedOperationException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -629,7 +643,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -645,7 +659,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder template = com.example.DataType.builder()")
@@ -660,7 +674,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -676,7 +690,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testBuilderClear_noBuilderFactory() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -703,7 +717,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testImmutableSetProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -729,7 +743,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testOverridingAdd() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -762,7 +776,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testOverridingAdd_primitive() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -795,7 +809,7 @@ public class MultisetPropertyFactoryTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTISET_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -832,7 +846,7 @@ public class MultisetPropertyFactoryTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")

--- a/src/test/java/org/inferred/freebuilder/processor/NullableMapperMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableMapperMethodTest.java
@@ -18,21 +18,34 @@ package org.inferred.freebuilder.processor;
 import com.google.common.base.Preconditions;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.List;
 
 import javax.annotation.Nullable;
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class NullableMapperMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_LAMBDAS;
+  }
 
   private static final JavaFileObject NULLABLE_INTEGER_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -44,13 +57,15 @@ public class NullableMapperMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void replacesValueToBeReturnedFromGetter() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -67,7 +82,7 @@ public class NullableMapperMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("property must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -97,7 +112,7 @@ public class NullableMapperMethodTest {
   public void throwsNpeIfMapperIsNull() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -111,7 +126,7 @@ public class NullableMapperMethodTest {
   public void throwsNpeIfMapperIsNullForUnsetNullableProperty() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -123,7 +138,7 @@ public class NullableMapperMethodTest {
   @Test
   public void allowsNullReturn() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -138,7 +153,7 @@ public class NullableMapperMethodTest {
   @Test
   public void skipsMapperIfNullablePropertyIsUnset() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder().mapProperty(a -> {")

--- a/src/test/java/org/inferred/freebuilder/processor/NullablePropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullablePropertyTest.java
@@ -18,21 +18,34 @@ package org.inferred.freebuilder.processor;
 import com.google.common.testing.EqualsTester;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.List;
 
 import javax.annotation.Nullable;
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class NullablePropertyTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
 
   private static final JavaFileObject TWO_NULLABLE_PROPERTIES_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -74,13 +87,15 @@ public class NullablePropertyTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testConstructor_defaultAbsent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -92,7 +107,7 @@ public class NullablePropertyTest {
   @Test
   public void testConstructor_primitive_defaultAbsent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder().build();")
@@ -104,7 +119,7 @@ public class NullablePropertyTest {
   @Test
   public void testBuilderGetter_defaultValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder();")
@@ -116,7 +131,7 @@ public class NullablePropertyTest {
   @Test
   public void testBuilderGetter_nonDefaultValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = new com.example.DataType.Builder()")
@@ -129,7 +144,7 @@ public class NullablePropertyTest {
   @Test
   public void testSet_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -143,7 +158,7 @@ public class NullablePropertyTest {
   @Test
   public void testSet_null() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -157,7 +172,7 @@ public class NullablePropertyTest {
   @Test
   public void testSet_primitive_notNull() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -171,7 +186,7 @@ public class NullablePropertyTest {
   @Test
   public void testSet_primitive_null() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_INTEGER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -185,7 +200,7 @@ public class NullablePropertyTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -201,7 +216,7 @@ public class NullablePropertyTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder template = com.example.DataType.builder()")
@@ -216,7 +231,7 @@ public class NullablePropertyTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -231,7 +246,7 @@ public class NullablePropertyTest {
   @Test
   public void testBuilderClear_customDefault() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -257,7 +272,7 @@ public class NullablePropertyTest {
   @Test
   public void testBuilderClear_noBuilderFactory() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -283,7 +298,7 @@ public class NullablePropertyTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -307,7 +322,7 @@ public class NullablePropertyTest {
   @Test
   public void testValueToString_singleField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType absent = com.example.DataType.builder()")
@@ -324,7 +339,7 @@ public class NullablePropertyTest {
   @Test
   public void testValueToString_twoFields() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_NULLABLE_PROPERTIES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType aa = com.example.DataType.builder()")
@@ -350,7 +365,7 @@ public class NullablePropertyTest {
   @Test
   public void testPartialToString_singleField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NULLABLE_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType absent = com.example.DataType.builder()")
@@ -367,7 +382,7 @@ public class NullablePropertyTest {
   @Test
   public void testPartialToString_twoFields() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_NULLABLE_PROPERTIES_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType aa = com.example.DataType.builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/OptionalMapperMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/OptionalMapperMethodTest.java
@@ -16,51 +16,72 @@
 package org.inferred.freebuilder.processor;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class OptionalMapperMethodTest {
 
-  private static final JavaFileObject J8_OPTIONAL_INTEGER_TYPE = new SourceBuilder()
-      .addLine("package com.example;")
-      .addLine("@%s", FreeBuilder.class)
-      .addLine("public interface DataType {")
-      .addLine("  %s<Integer> getProperty();", java.util.Optional.class)
-      .addLine("")
-      .addLine("  public static class Builder extends DataType_Builder {}")
-      .addLine("}")
-      .build();
+  @Parameters(name = "{1}: {0}")
+  public static List<Object[]> parameters() {
+    ImmutableList.Builder<Object[]> parameters = ImmutableList.builder();
+    for (FeatureSet features :  FeatureSets.WITH_LAMBDAS) {
+      parameters.add(new Object[] {
+          features,
+          java.util.Optional.class
+      });
+    }
+    for (FeatureSet features :  FeatureSets.WITH_GUAVA_AND_LAMBDAS) {
+      parameters.add(new Object[] {
+          features,
+          com.google.common.base.Optional.class
+      });
+    }
+    return parameters.build();
+  }
 
-  private static final JavaFileObject GUAVA_OPTIONAL_INTEGER_TYPE = new SourceBuilder()
-      .addLine("package com.example;")
-      .addLine("@%s", FreeBuilder.class)
-      .addLine("public interface DataType {")
-      .addLine("  %s<Integer> getProperty();", com.google.common.base.Optional.class)
-      .addLine("")
-      .addLine("  public static class Builder extends DataType_Builder {}")
-      .addLine("}")
-      .build();
+  private static JavaFileObject optionalIntegerType(Class<?> optionalType) {
+    return new SourceBuilder()
+        .addLine("package com.example;")
+        .addLine("@%s", FreeBuilder.class)
+        .addLine("public interface DataType {")
+        .addLine("  %s<Integer> getProperty();", optionalType)
+        .addLine("")
+        .addLine("  public static class Builder extends DataType_Builder {}")
+        .addLine("}")
+        .build();
+  }
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
+  @Parameter(value = 0) public FeatureSet features;
+  @Parameter(value = 1) public Class<?> optionalType;
 
   @Test
-  public void mapReplacesValueToBeReturnedFromGetterForJ8OptionalProperty() {
+  public void mapReplacesValueToBeReturnedFromGetter() {
     behaviorTester
-        .with(new Processor())
-        .with(J8_OPTIONAL_INTEGER_TYPE)
+        .with(new Processor(features))
+        .with(optionalIntegerType(optionalType))
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
             .addLine("    .setProperty(11)")
@@ -72,31 +93,16 @@ public class OptionalMapperMethodTest {
   }
 
   @Test
-  public void mapReplacesValueToBeReturnedFromGetterForGuavaOptionalProperty() {
-    behaviorTester
-        .with(new Processor())
-        .with(GUAVA_OPTIONAL_INTEGER_TYPE)
-        .with(new TestBuilder()
-            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
-            .addLine("    .setProperty(11)")
-            .addLine("    .mapProperty(a -> a + 3)")
-            .addLine("    .build();")
-            .addLine("assertEquals(14, (int) value.getProperty().get());")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mapDelegatesToSetterForValidationForJ8OptionalProperty() {
+  public void mapDelegatesToSetterForValidation() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("property must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
             .addLine("public interface DataType {")
-            .addLine("  %s<Integer> getProperty();", java.util.Optional.class)
+            .addLine("  %s<Integer> getProperty();", optionalType)
             .addLine("")
             .addLine("  public static class Builder extends DataType_Builder {")
             .addLine("    @Override public Builder setProperty(int property) {")
@@ -116,40 +122,11 @@ public class OptionalMapperMethodTest {
   }
 
   @Test
-  public void mapDelegatesToSetterForValidationForGuavaOptionalProperty() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("property must be non-negative");
-    behaviorTester
-        .with(new Processor())
-        .with(new SourceBuilder()
-            .addLine("package com.example;")
-            .addLine("@%s", FreeBuilder.class)
-            .addLine("public interface DataType {")
-            .addLine("  %s<Integer> getProperty();", com.google.common.base.Optional.class)
-            .addLine("")
-            .addLine("  public static class Builder extends DataType_Builder {")
-            .addLine("    @Override public Builder setProperty(int property) {")
-            .addLine("      %s.checkArgument(property >= 0, \"property must be non-negative\");",
-                Preconditions.class)
-            .addLine("      return super.setProperty(property);")
-            .addLine("    }")
-            .addLine("  }")
-            .addLine("}")
-            .build())
-        .with(new TestBuilder()
-            .addLine("new com.example.DataType.Builder()")
-            .addLine("    .setProperty(11)")
-            .addLine("    .mapProperty(a -> -3);")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mapThrowsNpeIfMapperIsNullForJ8OptionalProperty() {
+  public void mapThrowsNpeIfMapperIsNull() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
-        .with(J8_OPTIONAL_INTEGER_TYPE)
+        .with(new Processor(features))
+        .with(optionalIntegerType(optionalType))
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
             .addLine("    .setProperty(11)")
@@ -159,25 +136,11 @@ public class OptionalMapperMethodTest {
   }
 
   @Test
-  public void mapThrowsNpeIfMapperIsNullForGuavaOptionalProperty() {
+  public void mapThrowsNpeIfMapperIsNullAndPropertyIsEmpty() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
-        .with(GUAVA_OPTIONAL_INTEGER_TYPE)
-        .with(new TestBuilder()
-            .addLine("new com.example.DataType.Builder()")
-            .addLine("    .setProperty(11)")
-            .addLine("    .mapProperty(null);")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mapThrowsNpeIfMapperIsNullForEmptyJ8OptionalProperty() {
-    thrown.expect(NullPointerException.class);
-    behaviorTester
-        .with(new Processor())
-        .with(J8_OPTIONAL_INTEGER_TYPE)
+        .with(new Processor(features))
+        .with(optionalIntegerType(optionalType))
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
             .addLine("    .mapProperty(null);")
@@ -186,23 +149,10 @@ public class OptionalMapperMethodTest {
   }
 
   @Test
-  public void mapThrowsNpeIfMapperIsNullForAbsentGuavaOptionalProperty() {
-    thrown.expect(NullPointerException.class);
+  public void mapAllowsNullReturn() {
     behaviorTester
-        .with(new Processor())
-        .with(GUAVA_OPTIONAL_INTEGER_TYPE)
-        .with(new TestBuilder()
-            .addLine("new com.example.DataType.Builder()")
-            .addLine("    .mapProperty(null);")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mapAllowsNullReturnForJ8OptionalProperty() {
-    behaviorTester
-        .with(new Processor())
-        .with(J8_OPTIONAL_INTEGER_TYPE)
+        .with(new Processor(features))
+        .with(optionalIntegerType(optionalType))
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
             .addLine("    .setProperty(11)")
@@ -214,39 +164,10 @@ public class OptionalMapperMethodTest {
   }
 
   @Test
-  public void mapAllowsNullReturnForGuavaOptionalProperty() {
+  public void mapSkipsMapperIfPropertyIsEmpty() {
     behaviorTester
-        .with(new Processor())
-        .with(GUAVA_OPTIONAL_INTEGER_TYPE)
-        .with(new TestBuilder()
-            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
-            .addLine("    .setProperty(11)")
-            .addLine("    .mapProperty(a -> null)")
-            .addLine("    .build();")
-            .addLine("assertFalse(value.getProperty().isPresent());")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mapSkipsMapperIfJ8OptionalPropertyIsEmpty() {
-    behaviorTester
-        .with(new Processor())
-        .with(J8_OPTIONAL_INTEGER_TYPE)
-        .with(new TestBuilder()
-            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
-            .addLine("    .mapProperty(a -> { fail(\"mapper called\"); return null; })")
-            .addLine("    .build();")
-            .addLine("assertFalse(value.getProperty().isPresent());")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mapSkipsMapperIfGuavaOptionalPropertyIsAbsent() {
-    behaviorTester
-        .with(new Processor())
-        .with(GUAVA_OPTIONAL_INTEGER_TYPE)
+        .with(new Processor(features))
+        .with(optionalIntegerType(optionalType))
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
             .addLine("    .mapProperty(a -> { fail(\"mapper called\"); return null; })")

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -24,15 +24,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -46,8 +51,14 @@ import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class ProcessorTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
 
   private static final JavaFileObject NO_BUILDER_CLASS = new SourceBuilder()
       .addLine("package com.example;")
@@ -99,13 +110,15 @@ public class ProcessorTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testAbstractClass() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_PROPERTY_FREE_BUILDER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -121,7 +134,7 @@ public class ProcessorTest {
   @Test
   public void testInterface() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_PROPERTY_FREE_BUILDER_INTERFACE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -137,7 +150,7 @@ public class ProcessorTest {
   @Test
   public void test_nullPointerException() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(STRING_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("try {")
@@ -151,7 +164,7 @@ public class ProcessorTest {
   @Test
   public void testBuilderSerializability_nonSerializableSubclass() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_PROPERTY_FREE_BUILDER_TYPE)
         .with(new TestBuilder()
             .addLine("assertFalse(com.example.DataType.builder() instanceof %s);",
@@ -163,7 +176,7 @@ public class ProcessorTest {
   @Test
   public void testBuilderSerializability_serializableSubclass() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -191,7 +204,7 @@ public class ProcessorTest {
   @Test
   public void testFrom() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_PROPERTY_FREE_BUILDER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -211,7 +224,7 @@ public class ProcessorTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Not set: [propertyA, propertyB]");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -239,7 +252,7 @@ public class ProcessorTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Not set: [propertyA, propertyB]");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -269,7 +282,7 @@ public class ProcessorTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Not set: [propertyA, propertyB]");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -302,7 +315,7 @@ public class ProcessorTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Not set: [propertyA, propertyB]");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -333,7 +346,7 @@ public class ProcessorTest {
   @Test
   public void testClear_noBuilderFactory() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -362,7 +375,7 @@ public class ProcessorTest {
   @Test
   public void testPropertyNamedTemplate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -378,7 +391,7 @@ public class ProcessorTest {
   @Test
   public void testBuilderGetters() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_PROPERTY_FREE_BUILDER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType.Builder builder = com.example.DataType.builder()")
@@ -393,7 +406,7 @@ public class ProcessorTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_PROPERTY_FREE_BUILDER_TYPE)
         .with(new TestBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -455,7 +468,7 @@ public class ProcessorTest {
   @Test
   public void testDoubleEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -508,7 +521,7 @@ public class ProcessorTest {
   @Test
   public void testToString_noProperties() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -529,7 +542,7 @@ public class ProcessorTest {
   @Test
   public void testToString_oneProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(STRING_PROPERTY_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -543,7 +556,7 @@ public class ProcessorTest {
   @Test
   public void testToString_twoPrimitiveProperties() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(TWO_PROPERTY_FREE_BUILDER_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = com.example.DataType.builder()")
@@ -558,7 +571,7 @@ public class ProcessorTest {
   @Test
   public void testGwtSerialize_twoStringProperties() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -584,7 +597,7 @@ public class ProcessorTest {
   @Test
   public void testGwtSerialize_twoPrimitiveProperties() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -610,7 +623,7 @@ public class ProcessorTest {
   @Test
   public void testGwtSerialize_stringListProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -674,7 +687,7 @@ public class ProcessorTest {
   @Test
   public void testUnderriding_hashCodeAndEquals() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -730,7 +743,7 @@ public class ProcessorTest {
   @Test
   public void testUnderriding_toString() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -763,7 +776,7 @@ public class ProcessorTest {
   @Test
   public void testUnderriding_finalHashCodeEqualsAndToString() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -791,7 +804,7 @@ public class ProcessorTest {
   @Test
   public void testUnderriding_finalHashCodeAndEquals() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -829,7 +842,7 @@ public class ProcessorTest {
   @Test
   public void testUnderriding_finalToString() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -863,7 +876,7 @@ public class ProcessorTest {
   @Test
   public void testSiblingNameClashes() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("/** Block import of java.lang.String. #evil */")
@@ -890,7 +903,7 @@ public class ProcessorTest {
   @Test
   public void testNestedNameClashes() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("/** Clashes with the inner type generated by FreeBuilder. */")
@@ -918,7 +931,7 @@ public class ProcessorTest {
   @Test
   public void testBuilderClassIsEmpty_whenNotSubclassed() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(NO_BUILDER_CLASS)
         .with(new TestBuilder()
             .addLine("Class<?> builderClass = Class.forName(\"com.example.DataType_Builder\");")
@@ -932,7 +945,7 @@ public class ProcessorTest {
   public void testNestedClassHidingType() {
     // See also https://github.com/google/FreeBuilder/issues/61
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -959,7 +972,7 @@ public class ProcessorTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesTest.java
@@ -16,22 +16,34 @@
 package org.inferred.freebuilder.processor;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class RequiredPropertiesTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.ALL;
+  }
 
   private static final JavaFileObject REQUIRED_PROPERTIES_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -61,6 +73,8 @@ public class RequiredPropertiesTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
@@ -69,7 +83,7 @@ public class RequiredPropertiesTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Not set: [propertyB]");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -84,7 +98,7 @@ public class RequiredPropertiesTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Not set: [propertyB, propertyD]");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -112,7 +126,7 @@ public class RequiredPropertiesTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -130,7 +144,7 @@ public class RequiredPropertiesTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType.Builder template = new DataType.Builder()")
@@ -147,7 +161,7 @@ public class RequiredPropertiesTest {
   @Test
   public void testMergeFrom_builderIgnoresUnsetField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType.Builder template = new DataType.Builder()")
@@ -162,7 +176,7 @@ public class RequiredPropertiesTest {
   @Test
   public void testMergeFrom_noTemplate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE_NO_TEMPLATE)
         .with(testBuilder()
             .addImport(Optional.class)
@@ -181,7 +195,7 @@ public class RequiredPropertiesTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("propertyB not set");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType.Builder template = new DataType.Builder()")
@@ -196,7 +210,7 @@ public class RequiredPropertiesTest {
   @Test
   public void testBuildPartial_ignoresUnsetField() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -212,7 +226,7 @@ public class RequiredPropertiesTest {
     thrown.expect(UnsupportedOperationException.class);
     thrown.expectMessage("propertyB not set");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -226,7 +240,7 @@ public class RequiredPropertiesTest {
   @Test
   public void testBuildPartial_toString() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -240,7 +254,7 @@ public class RequiredPropertiesTest {
   @Test
   public void testBuildPartial_toString_twoPrimitiveProperties() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -258,7 +272,7 @@ public class RequiredPropertiesTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Not set: [propertyA, propertyB]");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -275,7 +289,7 @@ public class RequiredPropertiesTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("propertyB not set");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(REQUIRED_PROPERTIES_TYPE)
         .with(testBuilder()
             .addLine("new DataType.Builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/SetMultimapMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetMultimapMutateMethodTest.java
@@ -22,22 +22,34 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class SetMultimapMutateMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_GUAVA_AND_LAMBDAS;
+  }
 
   private static final JavaFileObject UNCHECKED_PROPERTY = new SourceBuilder()
       .addLine("package com.example;")
@@ -81,13 +93,15 @@ public class SetMultimapMutateMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void mutateAndPutModifiesUnderlyingProperty_whenUnchecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(UNCHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -108,7 +122,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutModifiesUnderlyingProperty_whenChecked() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -131,7 +145,7 @@ public class SetMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items.put(\"one\", \"\"));")
@@ -142,7 +156,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -159,7 +173,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllValuesModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -182,7 +196,7 @@ public class SetMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items")
@@ -194,7 +208,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllValuesKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -212,7 +226,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllMultimapModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -233,7 +247,7 @@ public class SetMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items")
@@ -245,7 +259,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllMultimapKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -263,7 +277,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndReplaceValuesModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -284,7 +298,7 @@ public class SetMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -298,7 +312,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndReplaceValuesKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -317,7 +331,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaGetModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -337,7 +351,7 @@ public class SetMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -350,7 +364,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaGetKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")
@@ -370,7 +384,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaAsMapModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -390,7 +404,7 @@ public class SetMultimapMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("value may not be empty");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -403,7 +417,7 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaAsMapKeepsSubstitute() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(INTERNED_PROPERTY)
         .with(testBuilder()
             .addLine("String s = new String(\"foobar\");")

--- a/src/test/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetMultimapPropertyFactoryTest.java
@@ -29,22 +29,34 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class SetMultimapPropertyFactoryTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_GUAVA;
+  }
 
   private static final JavaFileObject MULTIMAP_PROPERTY = new SourceBuilder()
       .addLine("package com.example;")
@@ -98,13 +110,15 @@ public class SetMultimapPropertyFactoryTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void testDefaultEmpty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder().build();")
@@ -117,7 +131,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testDefaultEmpty_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder().build();")
@@ -130,7 +144,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPut() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -149,7 +163,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPut_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -168,7 +182,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPut_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -187,7 +201,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPut_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -207,7 +221,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testPut_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -221,7 +235,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testPut_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -234,7 +248,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPut_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -254,7 +268,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -274,7 +288,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -294,7 +308,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -314,7 +328,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -335,7 +349,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testPutAllIterable_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -348,7 +362,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testPutAllIterable_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -360,7 +374,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -377,7 +391,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllIterable_iteratesOnce() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -413,7 +427,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -435,7 +449,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -457,7 +471,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -479,7 +493,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -502,7 +516,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testPutAllMultimap_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("%1$s<String, String> values = %1$s.create();", LinkedHashMultimap.class)
@@ -516,7 +530,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testPutAllMultimap_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("%1$s<String, String> values = %1$s.create();", LinkedHashMultimap.class)
@@ -529,7 +543,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testPutAllMultimap_duplicate() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -550,7 +564,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemove() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -572,7 +586,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemove_doesNotThrowIfEntryNotPresent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -593,7 +607,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemove_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -615,7 +629,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemove_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -637,7 +651,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemove_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -660,7 +674,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testRemove_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -674,7 +688,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testRemove_nullValue() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -687,7 +701,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -707,7 +721,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_doesNotThrowIfKeyNotPresent() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -725,7 +739,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_KEY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -745,7 +759,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVE_VALUE)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -765,7 +779,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testRemoveAll_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PRIMITIVES)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -786,7 +800,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testRemoveAll_nullKey() {
     thrown.expect(NullPointerException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
@@ -799,7 +813,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -820,7 +834,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testGet_returnsLiveView() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType.Builder builder = new DataType.Builder();")
@@ -840,7 +854,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testGet_returnsUnmodifiableSetMultimap() {
     thrown.expect(UnsupportedOperationException.class);
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType.Builder builder = new DataType.Builder();")
@@ -853,7 +867,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testMergeFrom_valueInstance() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = DataType.builder()")
@@ -874,7 +888,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testMergeFrom_builder() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType.Builder template = DataType.builder()")
@@ -894,7 +908,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testBuilderClear() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
@@ -915,7 +929,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testImmutableSetMultimapProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -945,7 +959,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -976,7 +990,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut_primitiveKey() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -1007,7 +1021,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut_primitiveValue() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -1038,7 +1052,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testOverridingPut_primitives() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("@%s", FreeBuilder.class)
@@ -1069,7 +1083,7 @@ public class SetMultimapPropertyFactoryTest {
   @Test
   public void testEquality() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(MULTIMAP_PROPERTY)
         .with(testBuilder()
             .addLine("new %s()", EqualsTester.class)
@@ -1103,7 +1117,7 @@ public class SetMultimapPropertyFactoryTest {
   public void testJacksonInteroperability() {
     // See also https://github.com/google/FreeBuilder/issues/68
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(new SourceBuilder()
             .addLine("package com.example;")
             .addLine("import " + JsonProperty.class.getName() + ";")

--- a/src/test/java/org/inferred/freebuilder/processor/SetMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetMutateMethodTest.java
@@ -19,23 +19,35 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import javax.tools.JavaFileObject;
 
-@RunWith(BehaviorTestRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class SetMutateMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> featureSets() {
+    return FeatureSets.WITH_LAMBDAS;
+  }
 
   private static final JavaFileObject UNCHECKED_SET_TYPE = new SourceBuilder()
       .addLine("package com.example;")
@@ -63,13 +75,15 @@ public class SetMutateMethodTest {
       .addLine("}")
       .build();
 
+  @Parameter public FeatureSet features;
+
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
   @Test
   public void mutateAndAddModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(UNCHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -84,7 +98,7 @@ public class SetMutateMethodTest {
   @Test
   public void mutateAndSizeReturnsSize() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -97,7 +111,7 @@ public class SetMutateMethodTest {
   @Test
   public void mutateAndContainsReturnsTrueForContainedElement() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -110,7 +124,7 @@ public class SetMutateMethodTest {
   @Test
   public void mutateAndIterateFindsContainedElement() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")
@@ -126,7 +140,7 @@ public class SetMutateMethodTest {
   @Test
   public void mutateAndRemoveModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -141,7 +155,7 @@ public class SetMutateMethodTest {
   @Test
   public void mutateAndCallRemoveOnIteratorModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -163,7 +177,7 @@ public class SetMutateMethodTest {
   @Test
   public void mutateAndClearModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("com.example.DataType value = new com.example.DataType.Builder()")
@@ -180,7 +194,7 @@ public class SetMutateMethodTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("elements must be non-negative");
     behaviorTester
-        .with(new Processor())
+        .with(new Processor(features))
         .with(CHECKED_SET_TYPE)
         .with(new TestBuilder()
             .addLine("new com.example.DataType.Builder()")

--- a/src/test/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilderTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilderTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -211,6 +212,7 @@ public class CompilationUnitBuilderTest {
     return new CompilationUnitBuilder(
         environment,
         QualifiedName.of(pkg, simpleName),
-        ImmutableSet.<QualifiedName>of());
+        ImmutableSet.<QualifiedName>of(),
+        new StaticFeatureSet());
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTesterTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTesterTest.java
@@ -37,7 +37,7 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 
-/** Unit tests for {@link SingleBehaviorTester}. */
+/** Unit tests for {@link BehaviorTester}. */
 @RunWith(JUnit4.class)
 public class BehaviorTesterTest {
 

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/SourceBuilder.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/SourceBuilder.java
@@ -101,8 +101,8 @@ public class SourceBuilder {
   /** Simple in-memory implementation of {@link javax.tools.JavaFileObject JavaFileObject}. */
   private static class Source extends SimpleJavaFileObject {
 
-    private final String content;
     private final String name;
+    private final String content;
 
     /**
      * Creates a new {@link javax.tools.JavaFileObject JavaFileObject} containing the supplied

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/TestBuilder.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/TestBuilder.java
@@ -28,7 +28,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 
 /**
- * Simple builder API for a test method, suitable for use in {@link SingleBehaviorTester}. See the
+ * Simple builder API for a test method, suitable for use in {@link BehaviorTester}. See the
  * JavaDoc on that class for an example.
  *
  * <p>Automatically imports {@link Assert}.* and {@link Truth#assertThat}.


### PR DESCRIPTION
Previously, all functional tests used the default environment feature set when running, i.e. only tested code generated for Java 8 with Guava. Parameterize all functional tests with the six feature set combinations currently supported (Java 6, 7 + 8, each with or without Guava). Additionally, parameterize OptionalMapperMethodTest with the Optional type (Java 8, Guava) instead of duplicating all tests.