### PR TITLE
Update version dynamically in gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,34 @@ book.getPublicationDate();
       </features>
 
 <script>
+  // Callback for GitHub API; fills out version tags with the latest version
+  updateVersions = function(response) {
+    // Return the largest array, considered lexicographically
+    maxArray = function(a, b) {
+      for (var i = 0; i < Math.min(a.length, b.length); i++) {
+        if (a[i] < b[i]) {
+          return b
+        } else if (a[i] > b[i]) {
+          return a
+        }
+      }
+      return (a.length < b.length) ? b : a
+    }
+
+    var latestTag = (response.data
+        .filter(function(tag) { return /^v\d+(\.\d+)+$/.test(tag.name) })
+        .map(function(tag) { return tag.name.substring(1).split(".").map(Number) })
+        .reduce(maxArray)
+        .join("."))
+    var versionFields = document.getElementsByTagName("version")
+    for (var i = 0; i < versionFields.length; i++) {
+      versionFields[i].innerText = latestTag
+    }
+  }
+</script>
+<script src="https://api.github.com/repos/google/FreeBuilder/tags?callback=updateVersions"></script>
+
+<script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/index.html
+++ b/index.html
@@ -224,8 +224,14 @@ book.getPublicationDate();
       </features>
 
 <script>
+  updateVersions = function(latestTag) {
+    var versionFields = document.getElementsByTagName("version")
+    for (var i = 0; i < versionFields.length; i++) {
+      versionFields[i].innerText = latestTag
+    }
+  }
   // Callback for GitHub API; fills out version tags with the latest version
-  updateVersions = function(response) {
+  updateVersionsCallback = function(response) {
     // Return the largest array, considered lexicographically
     maxArray = function(a, b) {
       for (var i = 0; i < Math.min(a.length, b.length); i++) {
@@ -243,13 +249,16 @@ book.getPublicationDate();
         .map(function(tag) { return tag.name.substring(1).split(".").map(Number) })
         .reduce(maxArray)
         .join("."))
-    var versionFields = document.getElementsByTagName("version")
-    for (var i = 0; i < versionFields.length; i++) {
-      versionFields[i].innerText = latestTag
+    if (typeof(Storage) !== "undefined") {
+      localStorage.latestFreeBuilder = latestTag
     }
+    updateVersions(latestTag)
+  }
+  if (typeof(Storage) !== "undefined" && localStorage.latestFreeBuilder !== null) {
+    updateVersions(localStorage.latestFreeBuilder)
   }
 </script>
-<script src="https://api.github.com/repos/google/FreeBuilder/tags?callback=updateVersions"></script>
+<script src="https://api.github.com/repos/google/FreeBuilder/tags?callback=updateVersionsCallback"></script>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@ book.getPublicationDate();
   // Callback for GitHub API; fills out version tags with the latest version
   updateVersionsCallback = function(response) {
     // Return the largest array, considered lexicographically
-    maxArray = function(a, b) {
+    var maxArray = function(a, b) {
       for (var i = 0; i < Math.min(a.length, b.length); i++) {
         if (a[i] < b[i]) {
           return b
@@ -250,12 +250,12 @@ book.getPublicationDate();
         .reduce(maxArray)
         .join("."))
     if (typeof(Storage) !== "undefined") {
-      localStorage.latestFreeBuilder = latestTag
+      localStorage.latestFreeBuilderVersion = latestTag
     }
     updateVersions(latestTag)
   }
-  if (typeof(Storage) !== "undefined" && localStorage.latestFreeBuilder !== null) {
-    updateVersions(localStorage.latestFreeBuilder)
+  if (typeof(Storage) !== "undefined" && localStorage.latestFreeBuilderVersion !== null) {
+    updateVersions(localStorage.latestFreeBuilderVersion)
   }
 </script>
 <script src="https://api.github.com/repos/google/FreeBuilder/tags?callback=updateVersionsCallback"></script>


### PR DESCRIPTION
Fetch the latest FreeBuilder version via GitHub's API, and replace placeholders in the text with it. This avoids accidentally leaving stale version number information on the site, but degrades gracefully if there are network errors. The version in cached in localStorage, so you only see the `<version>` text once, and can go offline without breaking the back button.