### PR TITLE
Fix unreliable Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 # sudo/dist/group must be required/trusty/edge to access oraclejdk9 (2016-11-14)
 sudo: required
 dist: trusty
-group: edge
 
 language: java
-jdk:
-  - oraclejdk8
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+      - oracle-java9-installer
 
 install: ./gradlew clean jar
 script: ./gradlew check


### PR DESCRIPTION
Attempting to enable Java 9 following the advice on [issue 5520](https://github.com/travis-ci/travis-ci/issues/5520#issuecomment-175914595) has resulted in the JDK 8 link that JAVA_HOME points to being intermittently deleted. Alternative advice on [issue 5897](https://github.com/travis-ci/travis-ci/issues/5897#issuecomment-211062030) appears to be more reliable.