### PR TITLE
Fix javadoc typo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ String jackson(String pkg) {
       namespace, pkg, jacksonVersion)
 }
 
+//// Testing /////////////////////////////////////////////////////
 test {
   maxHeapSize = "1024m"
 }
@@ -78,6 +79,7 @@ if (System.env.CI == 'true') {
     }
   }
 }
+check.dependsOn javadoc
 
 //// Checkstyle //////////////////////////////////////////////////
 checkstyle {

--- a/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
@@ -199,7 +199,7 @@ public class ModelUtils {
    *    interface X&lt;T&gt; {
    *      T getProperty();
    *    }
-   *    &#64;FreeBuilder interface Y&lt;T&gt; extends X&lt;List&lt;T&gt;&gt; { }</pre></code>
+   *    &#64;FreeBuilder interface Y&lt;T&gt; extends X&lt;List&lt;T&gt;&gt; { }</code></pre>
    *
    * <p>(Unfortunately, a bug in Eclipse prevents us handling these cases correctly at the moment.
    * javac works fine.)


### PR DESCRIPTION
Also run javadoc task as part of check in future, as this failure was only caught on the v1.11 tag build.