### PR TITLE
Add SourceLevel.JAVA_8

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
@@ -1,7 +1,7 @@
 package org.inferred.freebuilder.processor.util;
 
 import static java.util.Arrays.asList;
-import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
 import com.google.common.collect.ImmutableList;
 
@@ -78,7 +78,7 @@ public class Excerpts {
 
     @Override
     public void addTo(SourceBuilder code) {
-      if (code.feature(FUNCTION_PACKAGE).lambdasAvailable()) {
+      if (code.feature(SOURCE_LEVEL).hasLambdas()) {
         code.addLine("%s.forEach(this::%s);", iterable, method);
       } else {
         code.addLine("for (%s element : %s) {", elementType, iterable)

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/EnvironmentFeatureSet.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/EnvironmentFeatureSet.java
@@ -8,11 +8,11 @@ import javax.annotation.processing.ProcessingEnvironment;
 
 /**
  * A set of {@link Feature} instances, determined dynamically by calling
- * {@link FeatureType#forEnvironment(ProcessingEnvironment)}.
+ * {@link FeatureType#forEnvironment}.
  */
 public class EnvironmentFeatureSet implements FeatureSet {
 
-  private static class FeatureFromEnvironmentLoader
+  private class FeatureFromEnvironmentLoader
       extends CacheLoader<FeatureType<?>, Feature<?>> {
     private final ProcessingEnvironment env;
 
@@ -23,7 +23,7 @@ public class EnvironmentFeatureSet implements FeatureSet {
 
     @Override
     public Feature<?> load(FeatureType<?> featureType) {
-      return featureType.forEnvironment(env);
+      return featureType.forEnvironment(env, EnvironmentFeatureSet.this);
     }
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/FeatureType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/FeatureType.java
@@ -14,13 +14,13 @@ import javax.annotation.processing.ProcessingEnvironment;
 public abstract class FeatureType<F extends Feature<F>> {
 
   /** Returns the instance of {@code F} to use by default in tests. */
-  protected abstract F testDefault();
+  protected abstract F testDefault(FeatureSet features);
 
   /** Returns the instance of {@code F} to use in {@code env}. */
-  protected abstract F forEnvironment(ProcessingEnvironment env);
+  protected abstract F forEnvironment(ProcessingEnvironment env, FeatureSet features);
 
   @SuppressWarnings("unchecked")
   protected Class<F> type() {
-    return (Class<F>) testDefault().getClass();
+    return (Class<F>) testDefault(new StaticFeatureSet()).getClass();
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/FunctionPackage.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/FunctionPackage.java
@@ -1,18 +1,18 @@
 package org.inferred.freebuilder.processor.util.feature;
 
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
+
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
-import org.inferred.freebuilder.processor.util.Shading;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.util.Elements;
 
 /**
- * Types in the java.util.function package, if available. Defaults to {@link #UNAVAILABLE} in tests.
+ * Types in the java.util.function package, if available. Linked to the {@link SourceLevel} by
+ * default in tests.
  */
 public enum FunctionPackage implements Feature<FunctionPackage> {
 
@@ -26,24 +26,21 @@ public enum FunctionPackage implements Feature<FunctionPackage> {
       new FeatureType<FunctionPackage>() {
 
         @Override
-        protected FunctionPackage testDefault() {
-          return UNAVAILABLE;
+        protected FunctionPackage testDefault(FeatureSet features) {
+          return determineFromSourceLevel(features);
         }
 
         @Override
-        protected FunctionPackage forEnvironment(ProcessingEnvironment env) {
-          if (runningInEclipse()) {
-            // Eclipse is bugged: sourceVersion will never be > 7.
-            // Work around this by checking for the presence of java.util.function.Consumer instead.
-            return hasType(env.getElementUtils(), CONSUMER) ? AVAILABLE : UNAVAILABLE;
-          } else {
-            return hasLambdas(env.getSourceVersion()) ? AVAILABLE : UNAVAILABLE;
-          }
+        protected FunctionPackage forEnvironment(ProcessingEnvironment env, FeatureSet features) {
+          return determineFromSourceLevel(features);
+        }
+
+        private FunctionPackage determineFromSourceLevel(FeatureSet features) {
+          boolean isJava8OrHigher = features.get(SOURCE_LEVEL).compareTo(SourceLevel.JAVA_8) >= 0;
+          return isJava8OrHigher ? AVAILABLE : UNAVAILABLE;
         }
       };
 
-  private static final String ECLIPSE_DISPATCHER =
-      Shading.unshadedName("org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher");
   private static final ParameterizedType CONSUMER =
       QualifiedName.of("java.util.function", "Consumer").withParameters("T");
   private static final ParameterizedType BI_CONSUMER =
@@ -55,10 +52,6 @@ public enum FunctionPackage implements Feature<FunctionPackage> {
 
   FunctionPackage(String humanReadableFormat) {
     this.humanReadableFormat = humanReadableFormat;
-  }
-
-  public boolean lambdasAvailable() {
-    return (this == AVAILABLE);
   }
 
   /**
@@ -85,28 +78,6 @@ public enum FunctionPackage implements Feature<FunctionPackage> {
   @Override
   public String toString() {
     return humanReadableFormat;
-  }
-
-  private static boolean runningInEclipse() {
-    // If we're running in Eclipse, we will have been invoked by the Eclipse round dispatcher.
-    Throwable t = new Throwable();
-    t.fillInStackTrace();
-    for (StackTraceElement method : t.getStackTrace()) {
-      if (method.getClassName().equals(ECLIPSE_DISPATCHER)) {
-        return true;
-      } else if (!method.getClassName().startsWith("org.inferred")) {
-        return false;
-      }
-    }
-    return false;
-  }
-
-  private static boolean hasLambdas(SourceVersion version) {
-    return version.ordinal() >= 8;
-  }
-
-  private static boolean hasType(Elements elements, ParameterizedType type) {
-    return elements.getTypeElement(type.getQualifiedName().toString()) != null;
   }
 
   private <T> Optional<T> ifAvailable(T value) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/GuavaLibrary.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/GuavaLibrary.java
@@ -34,12 +34,12 @@ public enum GuavaLibrary implements Feature<GuavaLibrary> {
   public static final FeatureType<GuavaLibrary> GUAVA = new FeatureType<GuavaLibrary>() {
 
     @Override
-    protected GuavaLibrary testDefault() {
+    protected GuavaLibrary testDefault(FeatureSet features) {
       return UNAVAILABLE;
     }
 
     @Override
-    protected GuavaLibrary forEnvironment(ProcessingEnvironment env) {
+    protected GuavaLibrary forEnvironment(ProcessingEnvironment env, FeatureSet features) {
       String name = Shading.unshadedName(ImmutableList.class.getName());
       TypeElement element = env.getElementUtils().getTypeElement(name);
       return (element != null) ? AVAILABLE : UNAVAILABLE;

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/JavaxPackage.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/JavaxPackage.java
@@ -1,5 +1,8 @@
 package org.inferred.freebuilder.processor.util.feature;
 
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
+
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.util.QualifiedName;
@@ -9,7 +12,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.util.Elements;
 
 /**
- * Types in the javax package, if available. Defaults to {@link #AVAILABLE} in tests.
+ * Types in the javax package, if available. Linked to the {@link SourceLevel} by default in tests.
  */
 public enum JavaxPackage implements Feature<JavaxPackage> {
 
@@ -23,12 +26,13 @@ public enum JavaxPackage implements Feature<JavaxPackage> {
       new FeatureType<JavaxPackage>() {
 
         @Override
-        protected JavaxPackage testDefault() {
-          return AVAILABLE;
+        protected JavaxPackage testDefault(FeatureSet features) {
+          boolean isJava8OrHigher = features.get(SOURCE_LEVEL).compareTo(JAVA_8) >= 0;
+          return isJava8OrHigher ? UNAVAILABLE : AVAILABLE;
         }
 
         @Override
-        protected JavaxPackage forEnvironment(ProcessingEnvironment env) {
+        protected JavaxPackage forEnvironment(ProcessingEnvironment env, FeatureSet features) {
           return hasType(env.getElementUtils(), GENERATED) ? AVAILABLE : UNAVAILABLE;
         }
       };

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
@@ -19,22 +19,24 @@ import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.QualifiedName;
+import org.inferred.freebuilder.processor.util.Shading;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.util.Elements;
 
 /**
  * Compliance levels which are idiomatically supported by this processor.
  *
  * <p>{@link SourceVersion} is problematic to use, as the constants themselves will be missing
  * on compilers that do not support them (e.g. "RELEASE_8" is not available on javac v6 or v7).
- * Additionally, {@code sourceLevel.supportsDiamondOperator()} is far more readable than
+ * Additionally, {@code sourceLevel.javaUtilObjects().isPresent()} is far more readable than
  * {@code sourceVersion.compareTo(SourceLevel.RELEASE_7) >= 0}.
  */
 public enum SourceLevel implements Feature<SourceLevel> {
 
-  JAVA_6("Java 6"), JAVA_7("Java 7+");
+  JAVA_6("Java 6"), JAVA_7("Java 7"), JAVA_8("Java 8+");
 
   /**
    * Constant to pass to {@link SourceBuilder#feature(FeatureType)} to get the current
@@ -43,20 +45,33 @@ public enum SourceLevel implements Feature<SourceLevel> {
   public static final FeatureType<SourceLevel> SOURCE_LEVEL = new FeatureType<SourceLevel>() {
 
     @Override
-    protected SourceLevel testDefault() {
+    protected SourceLevel testDefault(FeatureSet features) {
       return JAVA_6;
     }
 
     @Override
-    protected SourceLevel forEnvironment(ProcessingEnvironment env) {
-      // RELEASE_6 is always available, as previous releases did not support annotation processing.
-      if (env.getSourceVersion().compareTo(SourceVersion.RELEASE_6) <= 0) {
+    protected SourceLevel forEnvironment(ProcessingEnvironment env, FeatureSet features) {
+      int sourceVersion = env.getSourceVersion().ordinal();
+
+      if (sourceVersion <= 6) {
+        // RELEASE_6 is always available, as previous releases did not support annotation processing
         return JAVA_6;
+      } else if (sourceVersion >= 8) {
+        // Return JAVA_8 for versions 9+ also.
+        return JAVA_8;
+      } else if (runningInEclipse()) {
+        // Some versions of Eclipse erroneously return RELEASE_7 instead of RELEASE_8.
+        // Work around this by checking for the presence of java.util.Stream instead.
+        return hasType(env.getElementUtils(), STREAM) ? JAVA_8 : JAVA_7;
       } else {
         return JAVA_7;
       }
     }
   };
+
+  private static final QualifiedName STREAM = QualifiedName.of("java.util.stream", "Stream");
+  private static final String ECLIPSE_DISPATCHER =
+      Shading.unshadedName("org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher");
 
   public static Excerpt diamondOperator(final Object type) {
     return new DiamondOperator(type);
@@ -105,8 +120,31 @@ public enum SourceLevel implements Feature<SourceLevel> {
     }
   }
 
+  public boolean hasLambdas() {
+    return compareTo(JAVA_8) >= 0;
+  }
+
   @Override
   public String toString() {
     return humanReadableFormat;
   }
+
+  private static boolean hasType(Elements elements, QualifiedName type) {
+    return elements.getTypeElement(type.toString()) != null;
+  }
+
+  private static boolean runningInEclipse() {
+    // If we're running in Eclipse, we will have been invoked by the Eclipse round dispatcher.
+    Throwable t = new Throwable();
+    t.fillInStackTrace();
+    for (StackTraceElement method : t.getStackTrace()) {
+      if (method.getClassName().equals(ECLIPSE_DISPATCHER)) {
+        return true;
+      } else if (!method.getClassName().startsWith("org.inferred")) {
+        return false;
+      }
+    }
+    return false;
+  }
+
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/StaticFeatureSet.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/StaticFeatureSet.java
@@ -4,7 +4,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Stores a set of {@link Feature} instances, defaulting to {@link FeatureType#testDefault()} when
+ * Stores a set of {@link Feature} instances, defaulting to {@link FeatureType#testDefault} when
  * asked for a type that was not explicitly registered.
  */
 public class StaticFeatureSet implements FeatureSet {
@@ -28,7 +28,7 @@ public class StaticFeatureSet implements FeatureSet {
 
   /**
    * Returns the registered instance of {@code featureType}, or the value of
-   * {@link FeatureType#testDefault()} if no explicit instance was registered with this set.
+   * {@link FeatureType#testDefault} if no explicit instance was registered with this set.
    */
   @Override
   public <T extends Feature<T>> T get(FeatureType<T> featureType) {
@@ -37,7 +37,7 @@ public class StaticFeatureSet implements FeatureSet {
     if (feature != null) {
       return feature;
     }
-    return featureType.testDefault();
+    return featureType.testDefault(this);
   }
 
   @Override

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.googlejavaformat.java.Formatter;
@@ -29,7 +30,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1047,17 +1047,12 @@ public class DefaultedPropertiesSourceTest {
   public void testJ8() {
     Metadata metadata = createMetadata(true);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/FeatureSets.java
+++ b/src/test/java/org/inferred/freebuilder/processor/FeatureSets.java
@@ -2,11 +2,11 @@ package org.inferred.freebuilder.processor;
 
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_6;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.processor.util.feature.FeatureSet;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 
@@ -18,25 +18,25 @@ final class FeatureSets {
   public static final List<FeatureSet> ALL = ImmutableList.of(
       new StaticFeatureSet(JAVA_6),
       new StaticFeatureSet(JAVA_7),
-      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE),
+      new StaticFeatureSet(JAVA_8),
       new StaticFeatureSet(JAVA_6, GuavaLibrary.AVAILABLE),
       new StaticFeatureSet(JAVA_7, GuavaLibrary.AVAILABLE),
-      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+      new StaticFeatureSet(JAVA_8, GuavaLibrary.AVAILABLE));
 
   /** For mapper and mutate method tests. */
   public static final List<FeatureSet> WITH_LAMBDAS = ImmutableList.of(
-      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE),
-      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+      new StaticFeatureSet(JAVA_8),
+      new StaticFeatureSet(JAVA_8, GuavaLibrary.AVAILABLE));
 
   /** For tests using Guava types. */
   public static final List<FeatureSet> WITH_GUAVA = ImmutableList.of(
       new StaticFeatureSet(JAVA_6, GuavaLibrary.AVAILABLE),
       new StaticFeatureSet(JAVA_7, GuavaLibrary.AVAILABLE),
-      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+      new StaticFeatureSet(JAVA_8, GuavaLibrary.AVAILABLE));
 
   /** For mutate method tests using Guava types. */
   public static final List<FeatureSet> WITH_GUAVA_AND_LAMBDAS = ImmutableList.of(
-      new StaticFeatureSet(JAVA_7, FunctionPackage.AVAILABLE, GuavaLibrary.AVAILABLE));
+      new StaticFeatureSet(JAVA_8, GuavaLibrary.AVAILABLE));
 
   private FeatureSets() {}
 }

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -18,6 +18,7 @@ package org.inferred.freebuilder.processor;
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.TypeVariableImpl.newTypeVariable;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.googlejavaformat.java.Formatter;
@@ -28,7 +29,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -572,17 +572,12 @@ public class GenericTypeSourceTest {
   public void testJ8() {
     Metadata metadata = createMetadata();
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder<A, B> {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -16,11 +16,11 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
-
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -35,7 +35,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -653,17 +652,12 @@ public class GuavaOptionalSourceTest {
   public void testJ8() {
     Metadata metadata = createMetadataWithOptionalProperties(true);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -16,11 +16,10 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
-
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
-import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -35,7 +34,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,17 +48,12 @@ public class JavaUtilOptionalSourceTest {
   public void testJ8() {
     Metadata metadata = createMetadataWithOptionalProperties(true);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",
@@ -368,16 +361,12 @@ public class JavaUtilOptionalSourceTest {
   public void testJ8_noGuava() {
     Metadata metadata = createMetadataWithOptionalProperties(true);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",
@@ -696,17 +685,12 @@ public class JavaUtilOptionalSourceTest {
   public void testPrefixless() {
     Metadata metadata = createMetadataWithOptionalProperties(false);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -20,6 +20,7 @@ import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLe
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -32,7 +33,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -682,17 +682,12 @@ public class ListSourceTest {
   public void test_guava_j8() {
     Metadata metadata = createMetadata(true);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // Currently also represents Java 8
-        GuavaLibrary.AVAILABLE,
-        FunctionPackage.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -18,6 +18,7 @@ package org.inferred.freebuilder.processor;
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
@@ -30,7 +31,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -451,17 +451,12 @@ public class NullableSourceTest {
 
   @Test
   public void testJ8() {
-    String source = generateSource(
-        metadata(true),
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata(true), JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.googlejavaformat.java.Formatter;
@@ -29,7 +30,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1110,17 +1110,12 @@ public class RequiredPropertiesSourceTest {
   public void testJ8() {
     Metadata metadata = createMetadata(true);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -31,7 +32,6 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.FunctionPackage;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -495,17 +495,12 @@ public class SetSourceTest {
   public void test_guava_j8() {
     Metadata metadata = createMetadata(true);
 
-    String source = generateSource(
-        metadata,
-        JAVA_7,  // SourceLevel does not currently distinguish J7 and J8
-        FunctionPackage.AVAILABLE,
-        GuavaLibrary.AVAILABLE);
+    String source = generateSource(metadata, JAVA_8, GuavaLibrary.AVAILABLE);
     assertThat(source).isEqualTo(Joiner.on('\n').join(
         "/**",
         " * Auto-generated superclass of {@link Person.Builder},",
         " * derived from the API of {@link Person}.",
         " */",
-        "@Generated(\"org.inferred.freebuilder.processor.CodeGenerator\")",
         "abstract class Person_Builder {",
         "",
         "  /**",

--- a/src/test/java/org/inferred/freebuilder/processor/util/feature/SourceLevelTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/feature/SourceLevelTest.java
@@ -40,9 +40,14 @@ public class SourceLevelTest {
     assertEquals(SourceLevel.JAVA_7, sourceLevelFrom(SourceVersion.RELEASE_7));
   }
 
+  @Test
+  public void java8() {
+    assertEquals(SourceLevel.JAVA_8, sourceLevelFrom(SourceVersion.RELEASE_8));
+  }
+
   private static SourceLevel sourceLevelFrom(SourceVersion version) {
     ProcessingEnvironment env = mock(ProcessingEnvironment.class);
     when(env.getSourceVersion()).thenReturn(version);
-    return SOURCE_LEVEL.forEnvironment(env);
+    return SOURCE_LEVEL.forEnvironment(env, null);
   }
 }


### PR DESCRIPTION
Previously, the FunctionPackage feature was standing in for this constant. After this refactoring, FunctionPackage defers to SourceLevel's logic to decide whether it's available or not, and tests can use simply `SourceLevel.JAVA_8` instead of both `SourceLevel.JAVA_7` and `FunctionPackage.AVAILABLE`. `FunctionPackage.lambdasAvailable()` has moved to the more obvious `SourceLevel.hasLambdas()`.

To allow FunctionPackage to determine whether SourceLevel is available, the FeatureType abstract class now takes a FeatureSet argument on its methods. Individual features are responsible for not creating cyclic dependencies. JavaxPackage uses this to disable itself by default in Java 8 tests, though it continues to defer to the processing environment in production.