### PR TITLE
Reduce build log verbosity on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - oracle-java9-installer
 
 install: ./gradlew clean jar
-script: ./gradlew check
+script: travis_wait 30 ./gradlew check
 
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -72,13 +72,6 @@ String jackson(String pkg) {
 test {
   maxHeapSize = "1024m"
 }
-if (System.env.CI == 'true') {
-  tasks.withType(Test) {
-    testLogging {
-      events "passed", "skipped", "failed"
-    }
-  }
-}
 check.dependsOn javadoc
 
 //// Checkstyle //////////////////////////////////////////////////


### PR DESCRIPTION
Travis assumes builds that don't produce output have timed out, so we were outputting a line per test to avoid this. However, due to test parameterization, we now have enough tests to overflow Travis's log viewer, which is making finding errors very difficult. Instead, use travis_wait to increase the timeout to 30 minutes.