### PR TITLE
Add support for SortedSet properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ nulls.
   List<String> descendants();
 ```
 
-A <code>[List][]</code>, <code>[Set][]</code> or <code>[Multiset][]</code>
+A <code>[List][]</code>, <code>[Set][]</code>, <code>[SortedSet][]</code> or <code>[Multiset][]</code>
 property called 'descendants' would generate:
 
 | Method | Description |
@@ -340,6 +340,7 @@ property called 'descendants' would generate:
 | `mutateDescendants(​Consumer<‌.‌.‌.‌<String>> mutator)` | *Java 8+* Invokes the [Consumer] `mutator` with the collection of descendants. (The mutator takes a list, set or map as appropriate.) Throws a NullPointerException if `mutator` is null. As `mutator` is a void consumer, any value returned from a lambda will be ignored, so be careful not to call pure functions like [stream()] expecting the returned collection to replace the existing collection. |
 | `clearDescendants()` | Removes all elements from the collection of descendants, leaving it empty. |
 | `descendants()` | Returns an unmodifiable view of the collection of descendants. Changes to the collection held by the builder will be reflected in the view. |
+| `setComparatorForDescendants(​Comparator<? super String> comparator)` | *SortedSet only* A protected method that sets the [comparator] to keep the set elements ordered by. Must be called before any other accessor method for this property. Defaults to the [natural ordering] of the set's elements. |
 
 ```java
   /** Returns a map of favourite albums by year. **/
@@ -387,13 +388,16 @@ personBuilder
     .mutateDescendants(Collections::sort);
 ```
 
+[Comparator]: https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html
 [List]: http://docs.oracle.com/javase/tutorial/collections/interfaces/list.html
 [Set]: http://docs.oracle.com/javase/tutorial/collections/interfaces/set.html
+[SortedSet]: http://docs.oracle.com/javase/8/docs/api/java/util/SortedSet.html
 [Spliterator]: https://docs.oracle.com/javase/8/docs/api/java/util/Spliterator.html
 [Stream]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html
 [Multiset]: https://github.com/google/guava/wiki/NewCollectionTypesExplained#multiset
 [Map]: http://docs.oracle.com/javase/tutorial/collections/interfaces/map.html
 [Multimap]: https://github.com/google/guava/wiki/NewCollectionTypesExplained#multimap
+[natural ordering]: https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html
 [sort]: http://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#sort-java.util.List-
 [stream()]: https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#stream--
 [subList]: http://docs.oracle.com/javase/8/docs/api/java/util/List.html#subList-int-int-

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -19,6 +19,9 @@ https://github.com/google/auto/blob/0c06a2345f71f053714d37bb6549d3460c999f2d/che
       <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>
 
+    <!-- Allow targetted suppression with @SuppressWarnings annotation -->
+    <module name="SuppressWarningsFilter"/>
+
     <!--module name="NewlineAtEndOfFile"/-->
     <module name="FileLength"/>
     <module name="FileTabCharacter"/>
@@ -150,5 +153,6 @@ https://github.com/google/auto/blob/0c06a2345f71f053714d37bb6549d3460c999f2d/che
 
         <!-- Enable suppression -->
         <module name="FileContentsHolder"/>
+        <module name="SuppressWarningsHolder"/>
     </module>
 </module>

--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -103,6 +103,7 @@ class Analyser {
       new NullablePropertyFactory(), // Must be first, as no other factory supports nulls
       new ListPropertyFactory(),
       new SetPropertyFactory(),
+      new SortedSetPropertyFactory(),
       new MapPropertyFactory(),
       new MultisetPropertyFactory(),
       new ListMultimapPropertyFactory(),

--- a/src/main/java/org/inferred/freebuilder/processor/BuilderMethods.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuilderMethods.java
@@ -61,6 +61,10 @@ public class BuilderMethods {
     return "removeAll" + property.getCapitalizedName();
   }
 
+  public static String setComparatorMethod(Property property) {
+    return "setComparatorFor" + property.getCapitalizedName();
+  }
+
   public static String setCountMethod(Property property) {
     return "setCountOf" + property.getCapitalizedName();
   }

--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetPropertyFactory.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor;
+
+import static org.inferred.freebuilder.processor.BuilderMethods.addAllMethod;
+import static org.inferred.freebuilder.processor.BuilderMethods.addMethod;
+import static org.inferred.freebuilder.processor.BuilderMethods.clearMethod;
+import static org.inferred.freebuilder.processor.BuilderMethods.getter;
+import static org.inferred.freebuilder.processor.BuilderMethods.mutator;
+import static org.inferred.freebuilder.processor.BuilderMethods.removeMethod;
+import static org.inferred.freebuilder.processor.BuilderMethods.setComparatorMethod;
+import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
+import static org.inferred.freebuilder.processor.Util.upperBound;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeUnbox;
+import static org.inferred.freebuilder.processor.util.ModelUtils.overrides;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
+import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
+import static org.inferred.freebuilder.processor.util.feature.SourceLevel.diamondOperator;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+
+import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
+import org.inferred.freebuilder.processor.excerpt.CheckedNavigableSet;
+import org.inferred.freebuilder.processor.util.Block;
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.Excerpts;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
+import org.inferred.freebuilder.processor.util.QualifiedName;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.StaticExcerpt;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+public class SortedSetPropertyFactory implements PropertyCodeGenerator.Factory {
+
+  @Override
+  public Optional<CodeGenerator> create(Config config) {
+    DeclaredType type = maybeDeclared(config.getProperty().getType()).orNull();
+    if (type == null || !erasesToAnyOf(type, SortedSet.class, ImmutableSortedSet.class)) {
+      return Optional.absent();
+    }
+
+    TypeMirror elementType = upperBound(config.getElements(), type.getTypeArguments().get(0));
+    Optional<TypeMirror> unboxedType = maybeUnbox(elementType, config.getTypes());
+    boolean overridesAddMethod = hasAddMethodOverride(config, unboxedType.or(elementType));
+    return Optional.of(new CodeGenerator(
+        config.getMetadata(), config.getProperty(), elementType, unboxedType, overridesAddMethod));
+  }
+
+  private static boolean hasAddMethodOverride(Config config, TypeMirror elementType) {
+    return overrides(
+        config.getBuilder(),
+        config.getTypes(),
+        addMethod(config.getProperty()),
+        elementType);
+  }
+
+  @VisibleForTesting
+  static class CodeGenerator extends PropertyCodeGenerator {
+
+    private static final ParameterizedType COLLECTION =
+        QualifiedName.of(Collection.class).withParameters("E");
+    private final TypeMirror elementType;
+    private final Optional<TypeMirror> unboxedType;
+    private final boolean overridesAddMethod;
+
+    CodeGenerator(
+        Metadata metadata,
+        Property property,
+        TypeMirror elementType,
+        Optional<TypeMirror> unboxedType,
+        boolean overridesAddMethod) {
+      super(metadata, property);
+      this.elementType = elementType;
+      this.unboxedType = unboxedType;
+      this.overridesAddMethod = overridesAddMethod;
+    }
+
+    @Override
+    public void addBuilderFieldDeclaration(SourceBuilder code) {
+      code.addLine("private %s<%s> %s = null;",
+          NavigableSet.class, elementType, property.getName());
+    }
+
+    @Override
+    public void addBuilderFieldAccessors(SourceBuilder code) {
+      addSetComparator(code, metadata);
+      addAdd(code, metadata);
+      addVarargsAdd(code, metadata);
+      addAddAllMethods(code, metadata);
+      addRemove(code, metadata);
+      addMutator(code, metadata);
+      addClear(code, metadata);
+      addGetter(code, metadata);
+    }
+
+    private void addSetComparator(SourceBuilder code, Metadata metadata) {
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Sets the comparator of the set to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" *")
+          .addLine(" * Pass in {@code null} to use the {@linkplain Comparable natural ordering}")
+          .addLine(" * of the elements.")
+          .addLine(" *")
+          .addLine(" * <p>If the set is accessed without calling this method first, the comparator")
+          .addLine(" * will default to {@code null}, and cannot subsequently be changed.")
+          .addLine(" * (Note that this immutability is an implementation detail that may change in")
+          .addLine(" * future; it should not be relied on for correctness.)")
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+          .addLine(" * @throws IllegalStateException if the set has been accessed at all,")
+          .addLine(" *     whether by adding an element, setting the comparator, or calling")
+          .addLine(" *     {@link #%s()}.", getter(property));
+      code.addLine(" */")
+          .addLine("protected %s %s(%s<? super %s> comparator) {",
+              metadata.getBuilder(),
+              setComparatorMethod(property),
+              Comparator.class,
+              elementType)
+          .add(PreconditionExcerpts.checkState(
+              Excerpts.add("%s == null", property.getName()),
+              "Comparator already set for %s",
+              property.getName()));
+      if (code.feature(GUAVA).isAvailable()) {
+        code.addLine("  if (comparator == null) {")
+            .addLine("    %s = %s.of();", property.getName(), ImmutableSortedSet.class)
+            .addLine("  } else {")
+            .addLine("    %s = new %s<%s>(comparator).build();",
+                property.getName(), ImmutableSortedSet.Builder.class, elementType)
+            .addLine("  }");
+      } else {
+        code.addLine("  %s = new %s%s(comparator);",
+            property.getName(), TreeSet.class, diamondOperator(elementType));
+      }
+      code.addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
+    private void addAdd(SourceBuilder code, Metadata metadata) {
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Adds {@code element} to the set to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" * If the set already contains {@code element}, then {@code %s}",
+              addMethod(property))
+          .addLine(" * has no effect (only the previously added element is retained).")
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+      if (!unboxedType.isPresent()) {
+        code.addLine(" * @throws NullPointerException if {@code element} is null");
+      }
+      code.addLine(" */")
+          .addLine("public %s %s(%s element) {",
+              metadata.getBuilder(),
+              addMethod(property),
+              unboxedType.or(elementType));
+      addConvertToTreeSet(code);
+      if (unboxedType.isPresent()) {
+        code.addLine("  this.%s.add(element);", property.getName());
+      } else {
+        code.add(checkNotNullPreamble("element"))
+            .addLine("  this.%s.add(%s);", property.getName(), checkNotNullInline("element"));
+      }
+      code.addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
+    private void addConvertToTreeSet(SourceBuilder code) {
+      code.addLine("  if (this.%s == null) {", property.getName())
+          .addLine("    // Use default comparator")
+          .addLine("    this.%s = new %s%s();",
+              property.getName(), TreeSet.class, diamondOperator(elementType));
+      if (code.feature(GUAVA).isAvailable()) {
+        code.addLine("  } else if (this.%s instanceof %s) {",
+                property.getName(), ImmutableSortedSet.class)
+            .addLine("    this.%1$s = new %2$s%3$s(this.%1$s);",
+                property.getName(), TreeSet.class, diamondOperator(elementType));
+      }
+      code.addLine("  }");
+    }
+
+    private void addVarargsAdd(SourceBuilder code, Metadata metadata) {
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Adds each element of {@code elements} to the set to be returned from")
+          .addLine(" * %s, ignoring duplicate elements",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" * (only the first duplicate element is added).")
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+      if (!unboxedType.isPresent()) {
+        code.addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
+            .addLine(" *     null element");
+      }
+      code.addLine(" */")
+          .addLine("public %s %s(%s... elements) {",
+              metadata.getBuilder(),
+              addMethod(property),
+              unboxedType.or(elementType));
+      Optional<Class<?>> arrayUtils = code.feature(GUAVA).arrayUtils(unboxedType.or(elementType));
+      if (arrayUtils.isPresent()) {
+        code.addLine("  return %s(%s.asList(elements));", addAllMethod(property), arrayUtils.get());
+      } else {
+        // Primitive type, Guava not available
+        code.addLine("  for (%s element : elements) {", elementType)
+            .addLine("    %s(element);", addMethod(property))
+            .addLine("  }")
+            .addLine("  return (%s) this;", metadata.getBuilder());
+      }
+      code.addLine("}");
+    }
+
+    private void addAddAllMethods(SourceBuilder code, Metadata metadata) {
+      if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
+        addSpliteratorAddAll(code, metadata);
+        addStreamAddAll(code, metadata);
+      }
+      addIterableAddAll(code, metadata);
+    }
+
+    private void addSpliteratorAddAll(SourceBuilder code, Metadata metadata) {
+      QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
+      addJavadocForAddAll(code, metadata);
+      code.addLine("public %s %s(%s<? extends %s> elements) {",
+              metadata.getBuilder(),
+              addAllMethod(property),
+              spliterator,
+              elementType)
+          .addLine("  elements.forEachRemaining(this::%s);", addMethod(property))
+          .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
+    private void addStreamAddAll(SourceBuilder code, Metadata metadata) {
+      QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
+      addJavadocForAddAll(code, metadata);
+      code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
+              metadata.getBuilder(),
+              addAllMethod(property),
+              baseStream,
+              elementType)
+          .addLine("  return %s(elements.spliterator());", addAllMethod(property))
+          .addLine("}");
+    }
+
+    private void addIterableAddAll(SourceBuilder code, Metadata metadata) {
+      addJavadocForAddAll(code, metadata);
+      addAccessorAnnotations(code);
+      code.addLine("public %s %s(%s<? extends %s> elements) {",
+              metadata.getBuilder(),
+              addAllMethod(property),
+              Iterable.class,
+              elementType)
+          .add(Excerpts.forEach(unboxedType.or(elementType), "elements", addMethod(property)))
+          .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
+    private void addJavadocForAddAll(SourceBuilder code, Metadata metadata) {
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Adds each element of {@code elements} to the set to be returned from")
+          .addLine(" * %s, ignoring duplicate elements",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" * (only the first duplicate element is added).")
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+          .addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
+          .addLine(" *     null element")
+          .addLine(" */");
+    }
+
+    private void addRemove(SourceBuilder code, Metadata metadata) {
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Removes {@code element} from the set to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" * Does nothing if {@code element} is not a member of the set.")
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+      if (!unboxedType.isPresent()) {
+        code.addLine(" * @throws NullPointerException if {@code element} is null");
+      }
+      code.addLine(" */")
+          .addLine("public %s %s(%s element) {",
+              metadata.getBuilder(),
+              removeMethod(property),
+              unboxedType.or(elementType));
+      addConvertToTreeSet(code);
+      if (unboxedType.isPresent()) {
+        code.addLine("  this.%s.remove(element);", property.getName());
+      } else {
+        code.add(checkNotNullPreamble("element"))
+            .addLine("  this.%s.remove(%s);", property.getName(), checkNotNullInline("element"));
+      }
+      code.addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
+    private void addMutator(SourceBuilder code, Metadata metadata) {
+      Optional<ParameterizedType> consumer = code.feature(FUNCTION_PACKAGE).consumer();
+      if (consumer.isPresent()) {
+        code.addLine("")
+            .addLine("/**")
+            .addLine(" * Applies {@code mutator} to the set to be returned from %s.",
+                metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            .addLine(" *")
+            .addLine(" * <p>This method mutates the set in-place. {@code mutator} is a void")
+            .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
+            .addLine(" * not to call pure functions, like %s.",
+                COLLECTION.javadocNoArgMethodLink("stream"))
+            .addLine(" *")
+            .addLine(" * @return this {@code Builder} object")
+            .addLine(" * @throws NullPointerException if {@code mutator} is null")
+            .addLine(" */")
+            .addLine("public %s %s(%s<? super %s<%s>> mutator) {",
+                metadata.getBuilder(),
+                mutator(property),
+                consumer.get().getQualifiedName(),
+                SortedSet.class,
+                elementType);
+        addConvertToTreeSet(code);
+        if (overridesAddMethod) {
+          code.addLine("  mutator.accept(new CheckedNavigableSet<%s>(%s, this::%s));",
+                  elementType, property.getName(), addMethod(property));
+        } else {
+          code.addLine("  // If %s is overridden, this method will be updated to delegate to it",
+                  addMethod(property))
+              .addLine("  mutator.accept(%s);", property.getName());
+        }
+        code.addLine("  return (%s) this;", metadata.getBuilder())
+            .addLine("}");
+      }
+    }
+
+    private void addClear(SourceBuilder code, Metadata metadata) {
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Clears the set to be returned from %s.",
+              metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" *")
+          .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+          .addLine(" */")
+          .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property));
+      if (code.feature(GUAVA).isAvailable()) {
+        code.addLine("  if (%s instanceof %s) {", property.getName(), ImmutableSortedSet.class)
+            .addLine("    %s = %s.of();", property.getName(), ImmutableSortedSet.class)
+            .add("  } else ");
+      }
+      code.addLine("  if (%s != null) {", property.getName())
+          .addLine("    %s.clear();", property.getName())
+          .addLine("  }")
+          .addLine("  return (%s) this;", metadata.getBuilder())
+          .addLine("}");
+    }
+
+    private void addGetter(SourceBuilder code, Metadata metadata) {
+      code.addLine("")
+          .addLine("/**")
+          .addLine(" * Returns an unmodifiable view of the set that will be returned by")
+          .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+          .addLine(" * Changes to this builder will be reflected in the view.")
+          .addLine(" */")
+          .addLine("public %s<%s> %s() {", SortedSet.class, elementType, getter(property));
+      addConvertToTreeSet(code);
+      code.addLine("  return %s.unmodifiableSortedSet(%s);", Collections.class, property.getName())
+          .addLine("}");
+    }
+
+    @Override
+    public void addFinalFieldAssignment(SourceBuilder code, String finalField, String builder) {
+      code.addLine("if (%s.%s == null) {", builder, property.getName());
+      if (code.feature(GUAVA).isAvailable()) {
+        code.addLine("  %s = %s.<%s>of();",
+                finalField, ImmutableSortedSet.class, elementType)
+            .addLine("} else if (%s.%s instanceof %s) {",
+                builder, property.getName(), ImmutableSortedSet.class)
+            .addLine("  %s = (%s<%s>) %s.%s;",
+                finalField, ImmutableSortedSet.class, elementType, builder, property.getName())
+            .addLine("} else {")
+            .addLine("  %s = %s.copyOfSorted(%s.%s);",
+                finalField, ImmutableSortedSet.class, builder, property.getName());
+      } else {
+        code.addLine("  %s = %s.unmodifiableSortedSet(new %s%s());",
+                finalField,
+                Collections.class,
+                TreeSet.class,
+                diamondOperator(elementType))
+            .addLine("} else {")
+            .addLine("  %s = %s.unmodifiableSortedSet(new %s%s(%s.%s));",
+                finalField,
+                Collections.class,
+                TreeSet.class,
+                diamondOperator(elementType),
+                builder,
+                property.getName());
+      }
+      code.addLine("}");
+    }
+
+    @Override
+    public void addMergeFromValue(Block code, String value) {
+      if (code.feature(GUAVA).isAvailable()) {
+        code.addLine("if (%s instanceof %s", value, metadata.getValueType().getQualifiedName())
+            .addLine("      && (%s == null", property.getName())
+            .addLine("          || (%s instanceof %s ",
+                property.getName(), ImmutableSortedSet.class)
+            .addLine("              && %s.isEmpty()", property.getName())
+            .addLine("              && %s))) {",
+                Excerpts.equals(
+                    Excerpts.add("%s.comparator()", property.getName()),
+                    Excerpts.add("%s.%s().comparator()", value, property.getGetterName())))
+            .addLine("  %1$s = (%2$s<%3$s>) (%2$s<?>) %4$s.%5$s();",
+                property.getName(),
+                ImmutableSortedSet.class,
+                elementType,
+                value,
+                property.getGetterName())
+            .addLine("} else {");
+      }
+      code.addLine("%s(%s.%s());", addAllMethod(property), value, property.getGetterName());
+      if (code.feature(GUAVA).isAvailable()) {
+        code.addLine("}");
+      }
+    }
+
+    @Override
+    public void addMergeFromBuilder(Block code, String builder) {
+      Excerpt base = Declarations.upcastToGeneratedBuilder(code, metadata, builder);
+      code.addLine("if (%s.%s != null) {", base, property.getName())
+          .addLine("  %s(%s.%s);", addAllMethod(property), base, property.getName())
+          .addLine("}");
+    }
+
+    @Override
+    public void addSetFromResult(SourceBuilder code, String builder, String variable) {
+      code.addLine("%s.%s(%s);", builder, addAllMethod(property), variable);
+    }
+
+    @Override
+    public void addClearField(Block code) {
+      code.addLine("%s();", clearMethod(property));
+    }
+
+    @Override
+    public Set<StaticExcerpt> getStaticExcerpts() {
+      ImmutableSet.Builder<StaticExcerpt> staticMethods = ImmutableSet.builder();
+      if (overridesAddMethod) {
+        staticMethods.addAll(CheckedNavigableSet.excerpts());
+      }
+      return staticMethods.build();
+    }
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedNavigableSet.java
+++ b/src/main/java/org/inferred/freebuilder/processor/excerpt/CheckedNavigableSet.java
@@ -1,0 +1,253 @@
+package org.inferred.freebuilder.processor.excerpt;
+
+import static org.inferred.freebuilder.processor.util.StaticExcerpt.Type.TYPE;
+import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FUNCTION_PACKAGE;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.StaticExcerpt;
+
+import java.util.AbstractSet;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NavigableSet;
+import java.util.Set;
+
+/**
+ * Excerpts defining a navigable set implementation that delegates to a provided add method to
+ * perform element validation and insertion into a backing set.
+ */
+public class CheckedNavigableSet {
+
+  public static Set<StaticExcerpt> excerpts() {
+    return ImmutableSet.of(CHECKED_NAVIGABLE_SET);
+  }
+
+  private static final StaticExcerpt CHECKED_NAVIGABLE_SET =
+      new StaticExcerpt(TYPE, "CheckedNavigableSet") {
+        @Override
+        @SuppressWarnings("checkstyle:methodlength")
+        public void addTo(SourceBuilder code) {
+          ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
+          if (consumer == null) {
+            return;
+          }
+          code.addLine("")
+              .addLine("/**")
+              .addLine(" * A set implementation that delegates to a provided add method")
+              .addLine(" * to perform element validation and insertion into a backing set.")
+              .addLine(" */")
+              .addLine("private static class CheckedNavigableSet<E>")
+              .addLine("    extends %s<E> implements %s<E> {",
+                  AbstractSet.class, NavigableSet.class)
+              .addLine("")
+              .addLine("  private final %s<E> set;", NavigableSet.class)
+              .addLine("  private final %s<E> add;", consumer.getQualifiedName())
+              .addLine("  private final E fromElement;")
+              .addLine("  private final boolean fromInclusive;")
+              .addLine("  private final E toElement;")
+              .addLine("  private final boolean toInclusive;")
+              .addLine("")
+              .addLine("  CheckedNavigableSet(%s<E> set, %s<E> add) {",
+                  NavigableSet.class, consumer.getQualifiedName())
+              .addLine("    this.set = set;")
+              .addLine("    this.add = add;")
+              .addLine("    this.fromElement = null;")
+              .addLine("    this.fromInclusive = false;")
+              .addLine("    this.toElement = null;")
+              .addLine("    this.toInclusive = false;")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  CheckedNavigableSet(")
+              .addLine("      %s<E> set,", NavigableSet.class)
+              .addLine("      %s<E> add,", consumer.getQualifiedName())
+              .addLine("      E fromElement,")
+              .addLine("      boolean fromInclusive,")
+              .addLine("      E toElement,")
+              .addLine("      boolean toInclusive) {")
+              .addLine("    this.set = set;")
+              .addLine("    this.add = add;")
+              .addLine("    this.fromElement = fromElement;")
+              .addLine("    this.fromInclusive = fromInclusive;")
+              .addLine("    this.toElement = toElement;")
+              .addLine("    this.toInclusive = toInclusive;")
+              .addLine("  }")
+              .addLine("")
+              .addLine("")
+              .addLine("  @Override public %s<E> iterator() {", Iterator.class)
+              .addLine("    return set.iterator();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public int size() {")
+              .addLine("    return set.size();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public boolean contains(Object e) {")
+              .addLine("    return set.contains(e);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public boolean add(E e) {")
+              .addLine("    if (fromElement != null || toElement != null) {")
+              .addLine("      %s<? super E> comparator = set.comparator();", Comparator.class)
+              .addLine("      if (comparator == null) {")
+              .addLine("        @SuppressWarnings(\"unchecked\")")
+              .addLine("        %1$s<? super E> lowerBound = (%1$s<? super E>) fromElement;",
+                  Comparable.class)
+              .addLine("        @SuppressWarnings(\"unchecked\")")
+              .addLine("        %1$s<? super E> upperBound = (%1$s<? super E>) toElement;",
+                  Comparable.class)
+              .add(PreconditionExcerpts.checkArgument(
+                  "lowerBound == null || lowerBound.compareTo(e) <= (fromInclusive ? 0 : -1)",
+                  "element must be %s %s (got %s)",
+                  "(fromInclusive ? \"at least\" : \"greater than\")",
+                  "lowerBound",
+                  "e"))
+              .add(PreconditionExcerpts.checkArgument(
+                  "upperBound == null || upperBound.compareTo(e) >= (toInclusive ? 0 : 1)",
+                  "element must be %s %s (got %s)",
+                  "(toInclusive ? \"at most\" : \"less than\")",
+                  "upperBound",
+                  "e"))
+              .addLine("      } else {")
+              .add(PreconditionExcerpts.checkArgument(
+                  "fromElement == null "
+                      + "|| comparator.compare(fromElement, e) <= (fromInclusive ? 0 : -1)",
+                  "element must be %s %s (got %s) using comparator %s",
+                  "(fromInclusive ? \"at least\" : \"greater than\")",
+                  "fromElement",
+                  "e",
+                  "comparator"))
+              .add(PreconditionExcerpts.checkArgument(
+                  "toElement == null "
+                      + "|| comparator.compare(toElement, e) >= (toInclusive ? 0 : 1)",
+                  "element must be %s %s (got %s) using comparator %s",
+                  "(toInclusive ? \"at most\" : \"less than\")",
+                  "toElement",
+                  "e",
+                  "comparator"))
+              .addLine("      }")
+              .addLine("    }")
+              .addLine("    if (!set.contains(e)) {")
+              .addLine("      add.accept(e);")
+              .addLine("      return true;")
+              .addLine("    } else {")
+              .addLine("      return false;")
+              .addLine("    }")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public boolean remove(Object e) {")
+              .addLine("    return set.remove(e);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<? super E> comparator() {", Comparator.class)
+              .addLine("    return set.comparator();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> subSet(E fromElement, E toElement) {",
+                  NavigableSet.class)
+              .add(PreconditionExcerpts.checkNotNull("fromElement"))
+              .add(PreconditionExcerpts.checkNotNull("toElement"))
+              .addLine("    %s<E> subSet = set.subSet(fromElement, true, toElement, false);",
+                  NavigableSet.class)
+              .addLine("    return new CheckedNavigableSet<>("
+                  + "subSet, add, fromElement, true, toElement, false);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> headSet(E toElement) {", NavigableSet.class)
+              .add(PreconditionExcerpts.checkNotNull("toElement"))
+              .addLine("    %s<E> headSet = set.headSet(toElement, false);", NavigableSet.class)
+              .addLine("    return new CheckedNavigableSet<>("
+                  + "headSet, add, fromElement, fromInclusive, toElement, false);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> tailSet(E fromElement) {", NavigableSet.class)
+              .add(PreconditionExcerpts.checkNotNull("fromElement"))
+              .addLine("    %s<E> tailSet = set.tailSet(fromElement, true);", NavigableSet.class)
+              .addLine("    return new CheckedNavigableSet<>("
+                  + "tailSet, add, fromElement, true, toElement, toInclusive);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E first() {")
+              .addLine("    return set.first();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E last() {")
+              .addLine("    return set.last();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E lower(E element) {")
+              .addLine("    return set.lower(element);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E floor(E element) {")
+              .addLine("    return set.floor(element);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E ceiling(E element) {")
+              .addLine("    return set.ceiling(element);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E higher(E element) {")
+              .addLine("    return set.higher(element);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E pollFirst() {")
+              .addLine("    return set.pollFirst();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public E pollLast() {")
+              .addLine("    return set.pollLast();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> descendingSet() {", NavigableSet.class)
+              .addLine("    %s<E> descendingSet = set.descendingSet();", NavigableSet.class)
+              .addLine("    return new CheckedNavigableSet("
+                  + "descendingSet, add, toElement, toInclusive, fromElement, fromInclusive);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> descendingIterator() {", Iterator.class)
+              .addLine("    return set.descendingIterator();")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> subSet(", NavigableSet.class)
+              .addLine("      E fromElement,")
+              .addLine("      boolean fromInclusive,")
+              .addLine("      E toElement,")
+              .addLine("      boolean toInclusive) {")
+              .add(PreconditionExcerpts.checkNotNull("fromElement"))
+              .add(PreconditionExcerpts.checkNotNull("toElement"))
+              .addLine("    %s<E> subSet = set.subSet("
+                  + "fromElement, fromInclusive, toElement, toInclusive);", NavigableSet.class)
+              .addLine("    return new CheckedNavigableSet<>("
+                  + "subSet, add, fromElement, fromInclusive, toElement, toInclusive);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> headSet(", NavigableSet.class)
+              .addLine("      E toElement,")
+              .addLine("      boolean inclusive) {")
+              .add(PreconditionExcerpts.checkNotNull("toElement"))
+              .addLine("    %s<E> headSet = set.headSet(toElement, inclusive);",
+                  NavigableSet.class)
+              .addLine("    return new CheckedNavigableSet<>("
+                  + "headSet, add, fromElement, fromInclusive, toElement, inclusive);")
+              .addLine("  }")
+              .addLine("")
+              .addLine("  @Override public %s<E> tailSet(", NavigableSet.class)
+              .addLine("      E fromElement,")
+              .addLine("      boolean inclusive) {")
+              .add(PreconditionExcerpts.checkNotNull("fromElement"))
+              .addLine("    %s<E> tailSet = set.tailSet(fromElement, inclusive);",
+                  NavigableSet.class)
+              .addLine("    return new CheckedNavigableSet<>("
+                  + "tailSet, add, fromElement, inclusive, toElement, toInclusive);")
+              .addLine("  }")
+              .addLine("}");
+        }
+      };
+
+  private CheckedNavigableSet() {}
+
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Excerpts.java
@@ -163,5 +163,36 @@ public class Excerpts {
     return new JoiningExcerpt(separator, excerpts);
   }
 
+  private static final class EqualsExcerpt extends Excerpt {
+    private final Object a;
+    private final Object b;
+
+    private EqualsExcerpt(Object a, Object b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    @Override
+    public void addTo(SourceBuilder source) {
+      QualifiedName objects = source.feature(SOURCE_LEVEL).javaUtilObjects().orNull();
+      if (objects != null) {
+        source.add("%s.equals(%s, %s)", objects, a, b);
+      } else {
+        source.add("(%1$s == %2$s || (%1$s != null && %1$s.equals(%2$s)))", a, b);
+      }
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("a", a);
+      fields.add("b", b);
+    }
+  }
+
+  /** Returns an excerpt equivalent to Java 7's {@code Object.equals(a, b)}. */
+  public static Object equals(Object a, Object b) {
+    return new EqualsExcerpt(a, b);
+  }
+
   private Excerpts() {}
 }

--- a/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
@@ -1,6 +1,9 @@
 package org.inferred.freebuilder.processor;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
 
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -12,10 +15,10 @@ public enum ElementFactory {
       "!element.isEmpty()",
       "Cannot add empty string",
       "",
-      "one",
-      "two",
-      "three",
-      "four"),
+      "alpha",
+      "beta",
+      "cappa",
+      "delta"),
   INTEGERS(
       "Integer",
       "int",
@@ -23,9 +26,9 @@ public enum ElementFactory {
       "Items must be non-negative",
       -4,
       1,
-      2,
       3,
-      4);
+      6,
+      10);
 
   private final String type;
   private final String unwrappedType;
@@ -47,6 +50,8 @@ public enum ElementFactory {
     this.errorMessage = errorMessage;
     this.invalidExample = invalidExample;
     this.examples = ImmutableList.copyOf(examples);
+    checkState(Ordering.natural().isOrdered(this.examples),
+        "Examples must be in natural order (got %s)", this.examples);
   }
 
   public String type() {

--- a/src/test/java/org/inferred/freebuilder/processor/SetType.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetType.java
@@ -1,0 +1,68 @@
+package org.inferred.freebuilder.processor;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.primitives.Ints;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.SortedSet;
+
+@SuppressWarnings("rawtypes")
+public enum SetType {
+  SET(Set.class, ImmutableSet.class) {
+    @Override
+    public int[] inOrder(int... exampleIds) {
+      return exampleIds;
+    }
+
+    @Override
+    public String intsInOrder(int... examples) {
+      return Joiner.on(", ").join(Ints.asList(examples));
+    }
+  },
+  SORTED_SET(SortedSet.class, ImmutableSortedSet.class) {
+    @Override
+    public int[] inOrder(int... exampleIds) {
+      int[] result = exampleIds.clone();
+      Arrays.sort(result);
+      return result;
+    }
+
+    @Override
+    public String intsInOrder(int... examples) {
+      int[] sortedExamples = examples.clone();
+      Arrays.sort(sortedExamples);
+      return Joiner.on(", ").join(Ints.asList(sortedExamples));
+    }
+  };
+
+  private final Class<? extends Set> setType;
+  private final Class<? extends ImmutableSet> immutableSetType;
+
+  SetType(Class<? extends Set> setType, Class<? extends ImmutableSet> immutableSetType) {
+    this.setType = setType;
+    this.immutableSetType = immutableSetType;
+    checkState(setType.isAssignableFrom(immutableSetType));
+  }
+
+  public Class<?> type() {
+    return setType;
+  }
+
+  public Class<?> immutableType() {
+    return immutableSetType;
+  }
+
+  public abstract int[] inOrder(int... exampleIds);
+
+  public abstract String intsInOrder(int... examples);
+
+  @Override
+  public String toString() {
+    return setType.getSimpleName();
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/SortedSetMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SortedSetMutateMethodTest.java
@@ -1,0 +1,537 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Ordering;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
+import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
+import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Stream;
+
+import javax.tools.JavaFileObject;
+
+/**
+ * Partial set of tests of {@link SortedSetPropertyFactory}. Tests common to unsorted tests can be
+ * found in {@link SetPropertyTest} and {@link SetMutateMethodTest}.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
+public class SortedSetMutateMethodTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> parameters() {
+    return FeatureSets.WITH_LAMBDAS;
+  }
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  @Shared public BehaviorTester behaviorTester;
+
+  private final FeatureSet features;
+
+  private static final String FAILED_VALIDATION_MESSAGE = "Elements cannot start with a '0'";
+
+  private static final JavaFileObject VALIDATED_SORTED_SET_PROPERTY_TYPE = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public abstract class DataType {")
+      .addLine("  public abstract %s<String> items();", SortedSet.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {")
+      .addLine("    @Override")
+      .addLine("    public Builder setComparatorForItems(%s<? super String> comparator) {",
+          Comparator.class)
+      .addLine("      return super.setComparatorForItems(comparator);")
+      .addLine("    }")
+      .addLine("")
+      .addLine("    @Override")
+      .addLine("    public Builder addItems(String element) {")
+      .addLine("      %s.checkArgument(!element.startsWith(\"0\"), \"%s\");",
+          Preconditions.class, FAILED_VALIDATION_MESSAGE)
+      .addLine("      return super.addItems(element);")
+      .addLine("    }")
+      .addLine("  }")
+      .addLine("}")
+      .build();
+
+  public SortedSetMutateMethodTest(FeatureSet features) {
+    this.features = features;
+  }
+
+  public static final Comparator<String> NATURAL_ORDER = new Comparator<String>() {
+    private final Comparator<String> delegate =
+        Ordering.natural().onResultOf(Integer::parseInt);
+
+    @Override
+    public int compare(String o1, String o2) {
+      return delegate.compare(o1, o2);
+    }
+
+    @Override
+    public String toString() {
+      return "'natural order'";
+    }
+  };
+
+  @Test
+  public void testGetsDataInOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        assertThat(items).containsExactly(\"3\", \"11\", \"222\").inOrder();")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testComparator() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        assertThat(items.comparator()).isEqualTo(NATURAL_ORDER);")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_contents() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"6\", \"11\", \"3\", \"222\", \"44\")")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"6\", \"44\");")
+            .addLine("        assertThat(subset).containsExactly(\"6\", \"11\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testHeadSet_contents() {
+    behaviorTester
+    .with(new Processor(features))
+    .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+    .with(testBuilder()
+        .addLine("new DataType.Builder()")
+        .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+        .addLine("    .addItems(\"6\", \"11\", \"3\", \"222\", \"44\")")
+        .addLine("    .mutateItems(items -> {")
+        .addLine("        Set<String> subset = items.headSet(\"44\");")
+        .addLine("        assertThat(subset).containsExactly(\"3\", \"6\", \"11\");")
+        .addLine("    });")
+        .build())
+    .runTest();
+  }
+
+  @Test
+  public void testTailSet_contents() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"6\", \"11\", \"3\", \"222\", \"44\")")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.tailSet(\"6\");")
+            .addLine("        assertThat(subset).containsExactly(\"6\", \"11\", \"44\", \"222\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_validatesInsertedItems() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(FAILED_VALIDATION_MESSAGE);
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"6\", \"44\");")
+            .addLine("        subset.add(\"007\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_permitsInsertionAtBoundaries_defaultOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"44\", \"6\");")
+            .addLine("        subset.add(\"44\");")
+            .addLine("        subset.add(\"599999\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"44\", \"599999\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_permitsInsertionAtBoundaries_naturalOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"6\", \"44\");")
+            .addLine("        subset.add(\"43\");")
+            .addLine("        subset.add(\"6\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"6\", \"43\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_deniesInsertionBelowLowerBound_defaultOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be at least 44 (got 4399)");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"44\", \"6\");")
+            .addLine("        subset.add(\"4399\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_deniesInsertionBelowLowerBound_naturalOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be at least 6 (got 5) using comparator 'natural order'");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"6\", \"44\");")
+            .addLine("        subset.add(\"5\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_deniesInsertionAtUpperBound_defaultOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be less than 6 (got 6)");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"44\", \"6\");")
+            .addLine("        subset.add(\"6\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_deniesInsertionAtUpperBound_naturalOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be less than 44 (got 44) using comparator 'natural order'");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.subSet(\"6\", \"44\");")
+            .addLine("        subset.add(\"44\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testHeadSet_validatesInsertedItems() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(FAILED_VALIDATION_MESSAGE);
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.headSet(\"44\");")
+            .addLine("        subset.add(\"007\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testHeadSet_permitsInsertionBelowUpperBound_defaultOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.headSet(\"6\");")
+            .addLine("        subset.add(\"44\");")
+            .addLine("        subset.add(\"599999\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"44\", \"599999\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testHeadSet_permitsInsertionBelowUpperBound_naturalOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.headSet(\"44\");")
+            .addLine("        subset.add(\"43\");")
+            .addLine("        subset.add(\"6\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"6\", \"43\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testHeadSet_deniesInsertionAtUpperBound_defaultOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be less than 6 (got 6)");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.headSet(\"6\");")
+            .addLine("        subset.add(\"6\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testHeadSet_deniesInsertionAtUpperBound_naturalOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be less than 44 (got 44) using comparator 'natural order'");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.headSet(\"44\");")
+            .addLine("        subset.add(\"44\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testTailSet_validatesInsertedItems() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(FAILED_VALIDATION_MESSAGE);
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.tailSet(\"6\");")
+            .addLine("        subset.add(\"007\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testTailSet_permitsInsertionAtLowerBound_defaultOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.tailSet(\"44\");")
+            .addLine("        subset.add(\"44\");")
+            .addLine("        subset.add(\"599999\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"44\", \"599999\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testTailSet_permitsInsertionAtLowerBound_naturalOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.tailSet(\"6\");")
+            .addLine("        subset.add(\"43\");")
+            .addLine("        subset.add(\"6\");")
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"6\", \"43\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testTailSet_deniesInsertionBelowLowerBound_defaultOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be at least 44 (got 4399)");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.tailSet(\"44\");")
+            .addLine("        subset.add(\"4399\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testTailSet_deniesInsertionBelowLowerBound_naturalOrder() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("element must be at least 6 (got 5) using comparator 'natural order'");
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        Set<String> subset = items.tailSet(\"6\");")
+            .addLine("        subset.add(\"5\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testFirstAndLastMatch() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"6\", \"11\", \"3\", \"222\", \"44\")")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        assertThat(items.first()).isEqualTo(\"3\");")
+            .addLine("        assertThat(items.last()).isEqualTo(\"222\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testSubSet_firstAndLastMatch() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(VALIDATED_SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"6\", \"11\", \"3\", \"222\", \"44\")")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("        SortedSet<String> subset = items.subSet(\"6\", \"44\");")
+            .addLine("        assertThat(subset.first()).isEqualTo(\"6\");")
+            .addLine("        assertThat(subset.last()).isEqualTo(\"11\");")
+            .addLine("    });")
+            .build())
+        .runTest();
+  }
+
+  private static TestBuilder testBuilder() {
+    return new TestBuilder()
+        .addImport("com.example.DataType")
+        .addStaticImport(SortedSetMutateMethodTest.class, "NATURAL_ORDER")
+        .addImport(Set.class)
+        .addImport(SortedSet.class)
+        .addImport(Stream.class);
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/SortedSetPropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SortedSetPropertyTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor;
+
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.junit.Assume.assumeTrue;
+
+import com.google.common.collect.Ordering;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
+import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
+import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
+import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
+import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.stream.Stream;
+
+import javax.tools.JavaFileObject;
+
+/**
+ * Partial set of tests of {@link SortedSetPropertyFactory}. Tests specific to the mutateX methods
+ * generated in Java 8+ are in {@link SortedSetMutateMethodTest}. Tests common to unsorted tests can
+ * be found in {@link SetPropertyTest} and {@link SetMutateMethodTest}.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
+public class SortedSetPropertyTest {
+
+  @Parameters(name = "{0}")
+  public static List<FeatureSet> parameters() {
+    return FeatureSets.ALL;
+  }
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  @Shared public BehaviorTester behaviorTester;
+
+  private final FeatureSet features;
+
+  private static final JavaFileObject SORTED_SET_PROPERTY_TYPE = new SourceBuilder()
+      .addLine("package com.example;")
+      .addLine("@%s", FreeBuilder.class)
+      .addLine("public abstract class DataType {")
+      .addLine("  public abstract %s<String> items();", SortedSet.class)
+      .addLine("")
+      .addLine("  public static class Builder extends DataType_Builder {")
+      .addLine("    @Override")
+      .addLine("    public Builder setComparatorForItems(%s<? super String> comparator) {",
+          Comparator.class)
+      .addLine("      return super.setComparatorForItems(comparator);")
+      .addLine("    }")
+      .addLine("  }")
+      .addLine("}")
+      .build();
+
+  public SortedSetPropertyTest(FeatureSet features) {
+    this.features = features;
+  }
+
+  public static final Comparator<String> NATURAL_ORDER =
+      Ordering.natural().onResultOf(Integer::parseInt);
+  public static final Comparator<String> EXPLICIT_DEFAULT_ORDER = String::compareTo;
+
+  @Test
+  public void testDefaultOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"11\", \"222\", \"3\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testNullOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(null)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"11\", \"222\", \"3\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testReverseOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(%s.reverseOrder())", Collections.class)
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"3\", \"222\", \"11\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testNaturalOrder() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items()).containsExactly(\"3\", \"11\", \"222\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testBuilderGetter() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType.Builder builder = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\");")
+            .addLine("assertThat(builder.items())")
+            .addLine("    .containsExactly(\"3\", \"11\", \"222\").inOrder();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testGetterComparator() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.items().comparator()).isEqualTo(NATURAL_ORDER);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testBuilderGetterComparator() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType.Builder builder = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\");")
+            .addLine("assertThat(builder.items().comparator()).isEqualTo(NATURAL_ORDER);")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testMergeFromReusesImmutableSetInstanceWhenComparatorsBothNull() {
+    assumeGuavaAvailable();
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(null)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("DataType copy = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(null)")
+            .addLine("    .mergeFrom(value)")
+            .addLine("    .build();")
+            .addLine("assertThat(copy.items()).isSameAs(value.items());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testMergeFromReusesImmutableSetInstanceWhenComparatorUnset() {
+    assumeGuavaAvailable();
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("DataType copy = new DataType.Builder()")
+            .addLine("    .mergeFrom(value)")
+            .addLine("    .build();")
+            .addLine("assertThat(copy.items()).isSameAs(value.items());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testMergeFromReusesImmutableSetInstanceWhenComparatorsMatch() {
+    assumeGuavaAvailable();
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("DataType copy = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(NATURAL_ORDER)")
+            .addLine("    .mergeFrom(value)")
+            .addLine("    .build();")
+            .addLine("assertThat(copy.items()).isSameAs(value.items());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testMergeFromDoesNotReuseImmutableSetInstanceWhenComparatorsDoNotMatch() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SORTED_SET_PROPERTY_TYPE)
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(null)")
+            .addLine("    .addItems(\"11\", \"3\", \"222\")")
+            .addLine("    .build();")
+            .addLine("DataType copy = new DataType.Builder()")
+            .addLine("    .setComparatorForItems(EXPLICIT_DEFAULT_ORDER)")
+            .addLine("    .mergeFrom(value)")
+            .addLine("    .build();")
+            .addLine("assertThat(copy.items()).isEqualTo(value.items());")
+            .addLine("assertThat(copy.items()).isNotSameAs(value.items());")
+            .build())
+        .runTest();
+  }
+
+  private void assumeGuavaAvailable() {
+    assumeTrue("Guava available", features.get(GUAVA).isAvailable());
+  }
+
+  private static TestBuilder testBuilder() {
+    return new TestBuilder()
+        .addImport("com.example.DataType")
+        .addStaticImport(SortedSetPropertyTest.class, "EXPLICIT_DEFAULT_ORDER")
+        .addStaticImport(SortedSetPropertyTest.class, "NATURAL_ORDER")
+        .addImport(Stream.class);
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/SharedBehaviorTesting.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/SharedBehaviorTesting.java
@@ -293,6 +293,11 @@ public class SharedBehaviorTesting {
     }
 
     @Override
+    public String toString() {
+      return method.getName();
+    }
+
+    @Override
     public BehaviorTester with(Processor processor) {
       processors.add(processor);
       return this;


### PR DESCRIPTION
These are treated very similarly to regular Set properties, except a protected `setComparatorForX` method is generated to allow a non-default comparator to be set at construction.

You might expect NavigableSet to be supported as well, since TreeSet and ImmutableSortedSet implement both, but unfortunately Collections only gained an `unmodifiableNavigableSet` method in Java 8. Support on Java 8+ may come in a later PR.