### PR TITLE
Retry closeRepository task for up to a minute before giving up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -584,6 +584,11 @@ ext['nexusPassword'] = System.env.NEXUS_PASSWORD
 
 apply plugin: 'io.codearte.nexus-staging'
 
+nexusStaging {
+  numberOfRetries = 20
+  delayBetweenRetriesInMillis = 3000
+}
+
 //// Eclipse /////////////////////////////////////////////////////
 eclipse.classpath {
   // We include sorceror so we can link against internal JVM classes.


### PR DESCRIPTION
Tag builds have been failing due to OSSRH taking a long time to promote the repository. Configure the task to retry less often (every 3s instead of every 1s) but more times (20 times instead of 7).