### PR TITLE
Disable duplicate Processor registrations

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Processor.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Processor.java
@@ -92,7 +92,7 @@ public class Processor extends AbstractProcessor {
   public synchronized void init(ProcessingEnvironment processingEnv) {
     super.init(processingEnv);
     if (registeredProcessors.putIfAbsent(processingEnv, this) != null) {
-      processingEnv.getMessager() .printMessage(
+      processingEnv.getMessager().printMessage(
           Kind.NOTE, "FreeBuilder processor registered twice; disabling duplicate instance");
       return;
     }
@@ -109,6 +109,7 @@ public class Processor extends AbstractProcessor {
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     if (analyser == null) {
+      // Another FreeBuilder Processor is already registered; skip processing
       return false;
     }
     for (TypeElement type : typesIn(annotatedElementsIn(roundEnv, FreeBuilder.class))) {

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -1105,4 +1105,22 @@ public class ProcessorTest {
         .runTest();
   }
 
+  @Test
+  public void testDoubleRegistration() {
+    // See also https://github.com/google/FreeBuilder/issues/21
+    behaviorTester
+        .with(new Processor(features))
+        .with(new Processor(features))
+        .with(TWO_PROPERTY_FREE_BUILDER_INTERFACE)
+        .with(new TestBuilder()
+            .addLine("com.example.DataType value = new com.example.DataType.Builder()")
+            .addLine("    .setPropertyA(11)")
+            .addLine("    .setPropertyB(true)")
+            .addLine("    .build();")
+            .addLine("assertEquals(11, value.getPropertyA());")
+            .addLine("assertTrue(value.isPropertyB());")
+            .build())
+        .compiles()
+        .withNoWarnings();
+  }
 }


### PR DESCRIPTION
We've had issues with toolchains mistakenly registering FreeBuilder twice with Eclipse. The resulting Filer errors were being caught and logged as warnings, but this PR instead outputs a single NOTE-level message and disables the duplicate processor.

This fixes #21.