### PR TITLE
Output full failure information when a transient test fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ String jackson(String pkg) {
 //// Testing /////////////////////////////////////////////////////
 test {
   maxHeapSize = "1024m"
+  testLogging {
+    exceptionFormat = 'full'
+  }
 }
 check.dependsOn javadoc
 


### PR DESCRIPTION
We're getting a lot of flakey NPEs on tests on Travis that I can't reproduce locally (even after running the test suite continuously for six hours). This change will hopefully give enough information to figure out what's going wrong.