### PR TITLE
Remove all dependencies from the FreeBuilder POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -564,6 +564,9 @@ modifyPom {
         timezone 'Europe/London'
       }
     }
+
+    // We shade all our dependencies
+    dependencies.clear()
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -529,6 +529,11 @@ if (System.env.TRAVIS_TAG != null && !System.env.TRAVIS_TAG.isEmpty()) {
 artifacts {
   archives shadowJar
 }
+configurations.archives.artifacts.with { archives ->
+  // Don't publish the unshaded jar
+  def unshadedJar = archives.findAll { it.classifier == 'only' }
+  archives.removeAll(unshadedJar)
+}
 
 modifyPom {
   project {


### PR DESCRIPTION
Since we shade all our dependencies, it doesn't make sense to include them in our POM. Also, there's no point in publishing the unshaded JAR.

This fixes #236.