### PR TITLE
Remove TravisCI addons section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ dist: trusty
 
 language: java
 
-# JDK 9 only available reliably as an add-on (2016-11-14)
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
-      - oracle-java9-installer
+jdk:
+  - oraclejdk8
 
 install: ./gradlew clean jar
 script: travis_wait 30 ./gradlew check


### PR DESCRIPTION
The oracle-java9-installer no longer works, but JDK 9 appears to be available reliably on TravisCI now (see travis-ci/travis-ci#7778).