### PR TITLE
Generate @SafeVarargs where necessary

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetPropertyFactory.java
@@ -25,6 +25,7 @@ import static org.inferred.freebuilder.processor.Util.erasesToAnyOf;
 import static org.inferred.freebuilder.processor.Util.upperBound;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeUnbox;
+import static org.inferred.freebuilder.processor.util.ModelUtils.needsSafeVarargs;
 import static org.inferred.freebuilder.processor.util.ModelUtils.overrides;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullInline;
 import static org.inferred.freebuilder.processor.util.PreconditionExcerpts.checkNotNullPreamble;
@@ -71,9 +72,18 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
 
     TypeMirror elementType = upperBound(config.getElements(), type.getTypeArguments().get(0));
     Optional<TypeMirror> unboxedType = maybeUnbox(elementType, config.getTypes());
+    boolean needsSafeVarargs = needsSafeVarargs(unboxedType.or(elementType));
     boolean overridesAddMethod = hasAddMethodOverride(config, unboxedType.or(elementType));
+    boolean overridesVarargsAddMethod =
+        hasVarargsAddMethodOverride(config, unboxedType.or(elementType));
     return Optional.of(new CodeGenerator(
-        config.getMetadata(), config.getProperty(), elementType, unboxedType, overridesAddMethod));
+        config.getMetadata(),
+        config.getProperty(),
+        elementType,
+        unboxedType,
+        needsSafeVarargs,
+        overridesAddMethod,
+        overridesVarargsAddMethod));
   }
 
   private static boolean hasAddMethodOverride(Config config, TypeMirror elementType) {
@@ -84,6 +94,14 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
         elementType);
   }
 
+  private static boolean hasVarargsAddMethodOverride(Config config, TypeMirror elementType) {
+    return overrides(
+        config.getBuilder(),
+        config.getTypes(),
+        addMethod(config.getProperty()),
+        config.getTypes().getArrayType(elementType));
+  }
+
   @VisibleForTesting
   static class CodeGenerator extends PropertyCodeGenerator {
 
@@ -91,18 +109,24 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
         QualifiedName.of(Collection.class).withParameters("E");
     private final TypeMirror elementType;
     private final Optional<TypeMirror> unboxedType;
+    private final boolean needsSafeVarargs;
     private final boolean overridesAddMethod;
+    private final boolean overridesVarargsAddMethod;
 
     CodeGenerator(
         Metadata metadata,
         Property property,
         TypeMirror elementType,
         Optional<TypeMirror> unboxedType,
-        boolean overridesAddMethod) {
+        boolean needsSafeVarargs,
+        boolean overridesAddMethod,
+        boolean overridesVarargsAddMethod) {
       super(metadata, property);
       this.elementType = elementType;
       this.unboxedType = unboxedType;
+      this.needsSafeVarargs = needsSafeVarargs;
       this.overridesAddMethod = overridesAddMethod;
+      this.overridesVarargsAddMethod = overridesVarargsAddMethod;
     }
 
     @Override
@@ -174,8 +198,21 @@ public class SetPropertyFactory implements PropertyCodeGenerator.Factory {
         code.addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
             .addLine(" *     null element");
       }
-      code.addLine(" */")
-          .addLine("public %s %s(%s... elements) {",
+      code.addLine(" */");
+      QualifiedName safeVarargs = code.feature(SOURCE_LEVEL).safeVarargs().orNull();
+      if (safeVarargs != null && needsSafeVarargs) {
+        if (!overridesVarargsAddMethod) {
+          code.addLine("@%s", safeVarargs)
+              .addLine("@%s({\"varargs\"})", SuppressWarnings.class);
+        } else {
+          code.addLine("@%s({\"unchecked\", \"varargs\"})", SuppressWarnings.class);
+        }
+      }
+      code.add("public ");
+      if (safeVarargs != null && needsSafeVarargs && !overridesVarargsAddMethod) {
+        code.add("final ");
+      }
+      code.add("%s %s(%s... elements) {\n",
               metadata.getBuilder(),
               addMethod(property),
               unboxedType.or(elementType));

--- a/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/feature/SourceLevel.java
@@ -110,6 +110,16 @@ public enum SourceLevel implements Feature<SourceLevel> {
     this.humanReadableFormat = humanReadableFormat;
   }
 
+  public Optional<QualifiedName> safeVarargs() {
+    switch (this) {
+      case JAVA_6:
+        return Optional.absent();
+
+      default:
+        return Optional.of(QualifiedName.of("java.lang", "SafeVarargs"));
+    }
+  }
+
   public Optional<QualifiedName> javaUtilObjects() {
     switch (this) {
       case JAVA_6:

--- a/src/test/java/org/inferred/freebuilder/processor/ListPrefixlessPropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListPrefixlessPropertyTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.feature.SourceLevel;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTestRunner.Shared;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
 import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
@@ -911,6 +912,104 @@ public class ListPrefixlessPropertyTest {
     behaviorTester
         .with(new Processor(features))
         .with(LIST_PROPERTY_AUTO_BUILT_TYPE)
+        .compiles()
+        .withNoWarnings();
+  }
+
+  @Test
+  public void testGenericFieldCompilesWithoutHeapPollutionWarnings() {
+    assumeTrue("Java 7+", features.get(SOURCE_LEVEL).compareTo(SourceLevel.JAVA_7) >= 0);
+    behaviorTester
+        .with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public abstract class DataType {")
+            .addLine("  public abstract %1$s<%1$s<%2$s>> items();", List.class, String.class)
+            .addLine("")
+            .addLine("  public static class Builder extends DataType_Builder {}")
+            .addLine("}")
+            .build())
+        .with(testBuilder()
+            .addLine("new DataType.Builder().addItems(")
+            .addLine("    ImmutableList.of(\"one\", \"two\"),")
+            .addLine("    ImmutableList.of(\"three\", \"four\"));")
+            .build())
+        .compiles()
+        .withNoWarnings();
+  }
+
+  @Test
+  public void testGenericBuildableTypeCompilesWithoutHeapPollutionWarnings() {
+    assumeTrue("Java 7+", features.get(SOURCE_LEVEL).compareTo(SourceLevel.JAVA_7) >= 0);
+    behaviorTester
+        .with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public abstract class DataType<T> {")
+            .addLine("  public abstract %s<T> items();", List.class)
+            .addLine("")
+            .addLine("  public static class Builder<T> extends DataType_Builder<T> {}")
+            .addLine("}")
+            .build())
+        .with(testBuilder()
+            .addLine("new DataType.Builder<String>().addItems(\"one\", \"two\")")
+            .addLine("    .build();")
+            .build())
+        .compiles()
+        .withNoWarnings();
+  }
+
+  @Test
+  public void testCanOverrideGenericFieldVarargsAdder() {
+    // Ensure we remove the final annotation needed to apply @SafeVarargs.
+    assumeTrue("Java 7+", features.get(SOURCE_LEVEL).compareTo(SourceLevel.JAVA_7) >= 0);
+    behaviorTester
+        .with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public abstract class DataType {")
+            .addLine("  public abstract %1$s<%1$s<%2$s>> items();", List.class, String.class)
+            .addLine("")
+            .addLine("  public static class Builder extends DataType_Builder {")
+            .addLine("    @%s", Override.class)
+            .addLine("    @%s", SafeVarargs.class)
+            .addLine("    @%s(\"varargs\")", SuppressWarnings.class)
+            .addLine("    public final Builder addItems(%s<%s>... items) {",
+                List.class, String.class)
+            .addLine("      return super.addItems(items);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}")
+            .build())
+        .compiles()
+        .withNoWarnings();
+  }
+
+  @Test
+  public void testCanOverrideGenericBuildableVarargsAdder() {
+    // Ensure we remove the final annotation needed to apply @SafeVarargs.
+    assumeTrue("Java 7+", features.get(SOURCE_LEVEL).compareTo(SourceLevel.JAVA_7) >= 0);
+    behaviorTester
+        .with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public abstract class DataType<T> {")
+            .addLine("  public abstract %s<T> items();", List.class)
+            .addLine("")
+            .addLine("  public static class Builder<T> extends DataType_Builder<T> {")
+            .addLine("    @%s", Override.class)
+            .addLine("    @%s", SafeVarargs.class)
+            .addLine("    @%s(\"varargs\")", SuppressWarnings.class)
+            .addLine("    public final Builder<T> addItems(T... items) {")
+            .addLine("      return super.addItems(items);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}")
+            .build())
         .compiles()
         .withNoWarnings();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -2009,11 +2009,11 @@ public class ListSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
-                metadata, name, false, string, Optional.<TypeMirror>absent()))
+                metadata, name, false, false, false, string, Optional.<TypeMirror>absent()))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new ListPropertyFactory.CodeGenerator(
-                metadata, age, false, integer, Optional.<TypeMirror>of(INT)))
+                metadata, age, false, false, false, integer, Optional.<TypeMirror>of(INT)))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -1453,7 +1453,7 @@ public class SetSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new SetPropertyFactory.CodeGenerator(
-                metadata, name, string, Optional.<TypeMirror>absent(), false))
+                metadata, name, string, Optional.<TypeMirror>absent(), false, false, false))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ModelUtilsTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ModelUtilsTest.java
@@ -1,0 +1,87 @@
+package org.inferred.freebuilder.processor.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.reflect.TypeToken;
+
+import org.inferred.freebuilder.processor.util.testing.ModelRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
+
+public class ModelUtilsTest {
+
+  @Rule public final ModelRule model = new ModelRule();
+
+  @Test
+  public void primitiveTypeDoesNotNeedSafeVarargs() {
+    TypeMirror intType = model.typeMirror(int.class);
+    assertFalse(ModelUtils.needsSafeVarargs(intType));
+  }
+
+  @Test
+  public void nonGenericTypeDoesNotNeedSafeVarargs() {
+    TypeMirror numberType = model.typeMirror(Number.class);
+    assertFalse(ModelUtils.needsSafeVarargs(numberType));
+  }
+
+  @Test
+  public void rawTypeDoesNotNeedSafeVarargs() {
+    TypeMirror rawType = model.typeMirror(List.class);
+    assertFalse(ModelUtils.needsSafeVarargs(rawType));
+  }
+
+  @Test
+  public void plainWildcardedListDoesNotNeedSafeVarargs() {
+    TypeMirror wildcardList = model.typeMirror(new TypeToken<List<?>>() {});
+    assertFalse(ModelUtils.needsSafeVarargs(wildcardList));
+  }
+
+  @Test
+  public void plainWildcardedMapDoesNotNeedSafeVarargs() {
+    TypeMirror wildcardMap = model.typeMirror(new TypeToken<Map<?, ?>>() {});
+    assertFalse(ModelUtils.needsSafeVarargs(wildcardMap));
+  }
+
+  @Test
+  public void parameterizedListNeedsSafeVarargs() {
+    TypeMirror parameterizedList = model.typeMirror(new TypeToken<List<String>>() {});
+    assertTrue(ModelUtils.needsSafeVarargs(parameterizedList));
+  }
+
+  @Test
+  public void parameterizedMapNeedsSafeVarargs() {
+    TypeMirror parameterizedMap = model.typeMirror(new TypeToken<Map<String, Double>>() {});
+    assertTrue(ModelUtils.needsSafeVarargs(parameterizedMap));
+  }
+
+  @Test
+  public void listWithLowerBoundedWildcardNeedsSafeVarargs() {
+    TypeMirror listWithLowerBoundedWildcard =
+        model.typeMirror(new TypeToken<List<? extends Number>>() {});
+    assertTrue(ModelUtils.needsSafeVarargs(listWithLowerBoundedWildcard));
+  }
+
+  @Test
+  public void listWithUpperBoundedWildcardNeedsSafeVarargs() {
+    TypeMirror listWithUpperBoundedWildcard =
+        model.typeMirror(new TypeToken<List<? super Number>>() {});
+    assertTrue(ModelUtils.needsSafeVarargs(listWithUpperBoundedWildcard));
+  }
+
+  @Test
+  public void typeArgumentNeedsSafeVarargs() {
+    ExecutableElement method = (ExecutableElement) model.newElementWithMarker(
+        "interface Foo<T> {",
+        "  ---> public T method();",
+        "}");
+    TypeMirror typeArgument = method.getReturnType();
+    assertTrue(ModelUtils.needsSafeVarargs(typeArgument));
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/SingleBehaviorTester.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/SingleBehaviorTester.java
@@ -151,7 +151,7 @@ class SingleBehaviorTester implements BehaviorTester {
       ClassLoader classLoader,
       Iterable<? extends TestFile> testFiles,
       boolean shouldSetContextClassLoader) {
-    final List<Throwable> exceptions = new ArrayList<Throwable>();
+    final List<Throwable> exceptions = new ArrayList<>();
     if (shouldSetContextClassLoader) {
       Thread t = new Thread() {
         @Override
@@ -205,12 +205,12 @@ class SingleBehaviorTester implements BehaviorTester {
       JavaFileManager fileManager,
       Iterable<? extends JavaFileObject> compilationUnits,
       Iterable<? extends Processor> processors) {
-    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     CompilationTask task = getCompiler().getTask(
         null,
         fileManager,
         diagnostics,
-        ImmutableList.of("-Xlint:unchecked", "-Xdiags:verbose"),
+        ImmutableList.of("-Xlint:unchecked", "-Xlint:varargs", "-Xdiags:verbose"),
         null,
         compilationUnits);
     task.setProcessors(processors);


### PR DESCRIPTION
`SuppressWarnings("varargs")` is also required due to the call to `Arrays.asList`, even though that's marked safe. Additionally, when leaving off `@SafeVarargs` to allow overriding, `unchecked` warnings need to be disabled.

This closes #180.