### PR TITLE
Fix SortedSetProperty clear bug

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
@@ -421,7 +421,14 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property));
     if (code.feature(GUAVA).isAvailable()) {
       code.addLine("  if (%s instanceof %s) {", property.getField(), ImmutableSortedSet.class)
-          .addLine("    %s = %s.of();", property.getField(), ImmutableSortedSet.class)
+          .addLine("    if (%s.isEmpty()) {", property.getField())
+          .addLine("       // Do nothing")
+          .addLine("    } else if (%s.comparator() != null) {", property.getField())
+          .addLine("      %1$s = new %2$s<%3$s>(%1$s.comparator()).build();",
+              property.getField(), ImmutableSortedSet.Builder.class, elementType)
+          .addLine("    } else {")
+          .addLine("      %s = %s.of();", property.getField(), ImmutableSortedSet.class)
+          .addLine("    }")
           .add("  } else ");
     }
     code.addLine("  if (%s != null) {", property.getField())

--- a/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
@@ -1,19 +1,30 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 
+import org.inferred.freebuilder.processor.testtype.AbstractNonComparable;
+import org.inferred.freebuilder.processor.testtype.NonComparable;
+import org.inferred.freebuilder.processor.testtype.OtherNonComparable;
 import org.inferred.freebuilder.processor.util.NameImpl;
 
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.annotation.Nullable;
+
 public enum ElementFactory {
   STRINGS(
+      String.class,
       "String",
-      "String",
+      null,
       CharSequence.class,
       "!element.isEmpty()",
       "!element.toString().isEmpty()",
@@ -28,8 +39,9 @@ public enum ElementFactory {
       "foxtrot",
       "golf"),
   INTEGERS(
-      "Integer",
+      Integer.class,
       "int",
+      null,
       Number.class,
       "element >= 0",
       "element.intValue() >= 0",
@@ -42,30 +54,50 @@ public enum ElementFactory {
       10,
       15,
       21,
-      28);
+      28),
+  NON_COMPARABLES(
+      NonComparable.class,
+      NonComparable.class.getName(),
+      AbstractNonComparable.ReverseIdComparator.class,
+      AbstractNonComparable.class,
+      "element.id() >= 0",
+      "element.id() >= 0",
+      "ID must be non-negative",
+      new NonComparable(-2, "broken"),
+      new OtherNonComparable(88, "other"),
+      new NonComparable(10, "alpha"),
+      new NonComparable(9, "cappa"),
+      new NonComparable(8, "echo"),
+      new NonComparable(7, "golf"),
+      new NonComparable(6, "beta"),
+      new NonComparable(5, "delta"),
+      new NonComparable(4, "foxtrot"));
 
-  private final String type;
+  private final Class<?> type;
   private final String unwrappedType;
+  @Nullable private final Class<?> comparator;
   private Class<?> supertype;
   private final String validation;
   private final String supertypeValidation;
   private final String errorMessage;
-  private final Comparable<?> invalidExample;
+  private final Object invalidExample;
   private final Object supertypeExample;
-  private final ImmutableList<Comparable<?>> examples;
+  private final ImmutableList<Object> examples;
 
   ElementFactory(
-      String type,
+      Class<?> type,
       String unwrappedType,
+      @Nullable Class<? extends Comparator<?>> comparator,
       Class<?> supertype,
       String validation,
       String supertypeValidation,
       String errorMessage,
-      Comparable<?> invalidExample,
+      Object invalidExample,
       Object supertypeExample,
-      Comparable<?>... examples) {
+      Object... examples) {
     this.type = type;
     this.unwrappedType = unwrappedType;
+    this.comparator = comparator;
     this.supertype = supertype;
     this.validation = validation;
     this.supertypeValidation = supertypeValidation;
@@ -73,16 +105,19 @@ public enum ElementFactory {
     this.invalidExample = invalidExample;
     this.supertypeExample = supertypeExample;
     this.examples = ImmutableList.copyOf(examples);
-    checkState(Ordering.natural().isOrdered(this.examples),
-        "Examples must be in natural order (got %s)", this.examples);
+    checkExamplesOrdered(comparator, this.examples);
   }
 
-  public String type() {
+  public Class<?> type() {
     return type;
   }
 
   public String unwrappedType() {
     return unwrappedType;
+  }
+
+  public Optional<Class<?>> comparator() {
+    return Optional.ofNullable(comparator);
   }
 
   public Class<?> supertype() {
@@ -121,18 +156,47 @@ public enum ElementFactory {
     return IntStream.of(ids).mapToObj(this::example).collect(Collectors.joining(", "));
   }
 
+  @Override
+  public String toString() {
+    return type.getSimpleName();
+  }
+
   private static String toSource(Object example) {
     if (example instanceof String) {
       return "\"" + example + "\"";
     } else if (example instanceof NameImpl) {
       return "new " + NameImpl.class.getName() + "(\"" + example + "\")";
+    } else if (example instanceof NonComparable) {
+      NonComparable nonComparable = (NonComparable) example;
+      return "new " + NonComparable.class.getName() + "(" + nonComparable.id() + ", \""
+          + nonComparable.name() + "\")";
+    } else if (example instanceof OtherNonComparable) {
+      OtherNonComparable otherNonComparable = (OtherNonComparable) example;
+      return "new " + OtherNonComparable.class.getName() + "(" + otherNonComparable.id() + ", \""
+          + otherNonComparable.name() + "\")";
     } else {
       return example.toString();
     }
   }
 
-  @Override
-  public String toString() {
-    return type;
+  private static void checkExamplesOrdered(
+      @Nullable Class<? extends Comparator<?>> comparator,
+      Collection<?> examples) {
+    if (comparator == null) {
+      List<Comparable<?>> comparables =
+          examples.stream().map(v -> (Comparable<?>) v).collect(toList());
+      checkState(Ordering.natural().isOrdered(comparables),
+          "Examples must be in natural order (got %s)", examples);
+    } else {
+      try {
+        @SuppressWarnings("rawtypes")
+        Ordering ordering = Ordering.from(comparator.newInstance());
+        @SuppressWarnings("unchecked")
+        boolean isOrdered = ordering.isOrdered(examples);
+        checkState(isOrdered);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
@@ -28,6 +28,7 @@ import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTest
 import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory.Shared;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -114,7 +115,7 @@ public class ListMutateMethodTest {
             elements.supertype());
     if (checked) {
       genericTypeBuilder
-          .addLine("    @Override public Builder addItems(T element) {")
+          .addLine("    @Override public Builder<T> addItems(T element) {")
           .addLine("      if (!(%s)) {", elements.supertypeValidation())
           .addLine("        throw new IllegalArgumentException(\"%s\");", elements.errorMessage())
           .addLine("      }")
@@ -143,6 +144,11 @@ public class ListMutateMethodTest {
     } else {
       internedStringsType = null;
     }
+  }
+
+  @Before
+  public void setUp() {
+    behaviorTester.withPermittedPackage(elements.type().getPackage());
   }
 
   @Test

--- a/src/test/java/org/inferred/freebuilder/processor/ListPropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListPropertyTest.java
@@ -35,6 +35,7 @@ import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTest
 import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory.Shared;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -115,6 +116,11 @@ public class ListPropertyTest {
         .addLine("  }")
         .addLine("}")
         .build();
+  }
+
+  @Before
+  public void setUp() {
+    behaviorTester.withPermittedPackage(elements.type().getPackage());
   }
 
   @Test

--- a/src/test/java/org/inferred/freebuilder/processor/SetType.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetType.java
@@ -57,6 +57,10 @@ public enum SetType {
     return immutableSetType;
   }
 
+  public boolean isSorted() {
+    return SortedSet.class.isAssignableFrom(setType);
+  }
+
   public abstract int[] inOrder(int... exampleIds);
 
   public abstract String intsInOrder(int... examples);

--- a/src/test/java/org/inferred/freebuilder/processor/testtype/AbstractNonComparable.java
+++ b/src/test/java/org/inferred/freebuilder/processor/testtype/AbstractNonComparable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor.testtype;
+
+import java.util.Comparator;
+
+public abstract class AbstractNonComparable {
+
+  public abstract int id();
+
+  public static final class ReverseIdComparator implements Comparator<AbstractNonComparable> {
+    @Override
+    public int compare(AbstractNonComparable o1, AbstractNonComparable o2) {
+      return Integer.compare(o2.id(), o1.id());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return (obj instanceof ReverseIdComparator);
+    }
+
+    @Override
+    public int hashCode() {
+      return getClass().hashCode();
+    }
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/testtype/NonComparable.java
+++ b/src/test/java/org/inferred/freebuilder/processor/testtype/NonComparable.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor.testtype;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class NonComparable extends AbstractNonComparable {
+
+  private final int id;
+  private final String name;
+
+  @JsonCreator
+  public NonComparable(@JsonProperty("id") int id, @JsonProperty("name") String name) {
+    this.id = requireNonNull(id);
+    this.name = requireNonNull(name);
+  }
+
+  @Override
+  @JsonProperty("id")
+  public int id() {
+    return id;
+  }
+
+  @JsonProperty("name")
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof NonComparable)) {
+      return false;
+    }
+    NonComparable other = (NonComparable) obj;
+    return (id == other.id) && (name.equals(other.name));
+  }
+
+  @Override
+  public String toString() {
+    return "NonComparable [id=" + id + ", name=" + name + "]";
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/testtype/OtherNonComparable.java
+++ b/src/test/java/org/inferred/freebuilder/processor/testtype/OtherNonComparable.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor.testtype;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+public class OtherNonComparable extends AbstractNonComparable {
+
+  private final int id;
+  private final String name;
+
+  public OtherNonComparable(int id, String name) {
+    this.id = requireNonNull(id);
+    this.name = requireNonNull(name);
+  }
+
+  @Override
+  public int id() {
+    return id;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof OtherNonComparable)) {
+      return false;
+    }
+    OtherNonComparable other = (OtherNonComparable) obj;
+    return (id == other.id) && (name.equals(other.name));
+  }
+
+  @Override
+  public String toString() {
+    return "OtherNonComparable [id=" + id + ", name=" + name + "]";
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/BehaviorTester.java
@@ -111,6 +111,11 @@ public interface BehaviorTester {
   BehaviorTester withContextClassLoader();
 
   /**
+   * Whitelists a specific package for access by generated code.
+   */
+  BehaviorTester withPermittedPackage(Package pkg);
+
+  /**
    * Compiles everything given to {@link #with}.
    *
    * @return a {@link CompilationSubject} with which to make further assertions

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/SharedBehaviorTesting.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/SharedBehaviorTesting.java
@@ -289,6 +289,7 @@ public class SharedBehaviorTesting {
     final FrameworkMethod method;
     boolean unmergeable = false;
     final Set<Processor> processors = new LinkedHashSet<>();
+    final Set<Package> permittedPackages = new LinkedHashSet<>();
     final List<JavaFileObject> compilationUnits = new ArrayList<>();
     final List<TestSource> testSources = new ArrayList<>();
 
@@ -316,6 +317,12 @@ public class SharedBehaviorTesting {
     @Override
     public BehaviorTester with(TestSource testSource) {
       testSources.add(testSource);
+      return this;
+    }
+
+    @Override
+    public BehaviorTester withPermittedPackage(Package pkg) {
+      permittedPackages.add(pkg);
       return this;
     }
 
@@ -359,6 +366,7 @@ public class SharedBehaviorTesting {
     private CompilationSubject subject;
     private RuntimeException compilationException;
     private final FeatureSet features;
+    private final Set<Package> permittedPackages = new LinkedHashSet<>();
 
     SharedCompiler(Child child, FeatureSet features) {
       children.add(child.method);
@@ -367,6 +375,7 @@ public class SharedBehaviorTesting {
       for (JavaFileObject compilationUnit : child.compilationUnits) {
         compilationUnits.put(compilationUnit.getName(), compilationUnit);
       }
+      permittedPackages.addAll(child.permittedPackages);
       testSources.addAll(child.testSources);
       this.features = features;
     }
@@ -392,6 +401,9 @@ public class SharedBehaviorTesting {
       for (JavaFileObject compilationUnit : child.compilationUnits) {
         compilationUnits.put(compilationUnit.getName(), compilationUnit);
       }
+      for (Package pkg : child.permittedPackages) {
+        permittedPackages.add(pkg);
+      }
       testSources.addAll(child.testSources);
       return this;
     }
@@ -411,6 +423,9 @@ public class SharedBehaviorTesting {
         }
         for (TestSource testSource : testSources) {
           tester.with(testSource);
+        }
+        for (Package pkg : permittedPackages) {
+          tester.withPermittedPackage(pkg);
         }
         try {
           subject = tester.compiles();
@@ -455,6 +470,12 @@ public class SharedBehaviorTesting {
     public BehaviorTester with(TestSource testSource) {
       testSources.add(testSource);
       fallbackCompiler.with(testSource);
+      return this;
+    }
+
+    @Override
+    public BehaviorTester withPermittedPackage(Package pkg) {
+      fallbackCompiler.withPermittedPackage(pkg);
       return this;
     }
 


### PR DESCRIPTION
Clearing a SortedSet property was accidentally removing the comparator when Guava is available. Extended the set of element types in our build matrix to include one that is not Comparable, which catches this bug.

This fixes #265.