### PR TITLE
Fix build to work with Java 9.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - oracle-java9-installer
 
 install: ./gradlew clean jar
-script: travis_wait 30 ./gradlew check
+script: ./gradlew check
 
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ task vanillaTest {
     }
     reports {
       html {
-        destination "$reportsDir/vanilla${jdk}"
+        destination file("$reportsDir/vanilla${jdk}")
       }
     }
   }
@@ -352,7 +352,7 @@ task gwtTest(type: Test) {
   classpath = sourceSets.gwtTest.runtimeClasspath
   reports {
     html {
-      destination "$reportsDir/gwt"
+      destination file("$reportsDir/gwt")
     }
   }
   testLogging.showStandardStreams = true
@@ -419,7 +419,7 @@ task noGuavaTest {
     classpath = sourceSets["noGuava${jdk}Test"].runtimeClasspath
     reports {
       html {
-        destination "$reportsDir/noGuava${jdk}"
+        destination file("$reportsDir/noGuava${jdk}")
       }
     }
   }
@@ -465,7 +465,7 @@ task noGuavaJ8Test(type: Test) {
   classpath = sourceSets.noGuavaJ8Test.runtimeClasspath
   reports {
     html {
-      destination "$reportsDir/noGuavaJ8"
+      destination file("$reportsDir/noGuavaJ8")
     }
   }
 }
@@ -511,7 +511,7 @@ task("lambdaTest", type: Test) {
   classpath = sourceSets["lambdaTest"].runtimeClasspath
   reports {
     html {
-      destination "$reportsDir/lambda"
+      destination file("$reportsDir/lambda")
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ plugins {
   id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
+apply from: "gradle/travis-keep-alive.gradle"
+
 repositories {
   mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -196,11 +196,6 @@ afterEvaluate {
       }
     }
   }
-  tasks.withType(Test) {
-    if (executable == java9.java) {
-      jvmArgs += ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
-    }
-  }
 }
 
 //// Vanilla integration tests ///////////////////////////////////

--- a/build.gradle
+++ b/build.gradle
@@ -192,8 +192,7 @@ afterEvaluate {
   tasks.withType(JavaCompile) {
     if (targetCompatibility == "1.9") {
       options.with {
-        fork = true
-        forkOptions.executable = java9.javac
+        fork javaHome: file(java9Home)
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ check.dependsOn javadoc
 //// Checkstyle //////////////////////////////////////////////////
 checkstyle {
   toolVersion = "6.19"
-  configProperties['config_loc'] = "$rootDir/config/checkstyle"
+  configProperties.configDir = "$rootDir/config/checkstyle"
 }
 
 tasks.withType(Checkstyle).each { checkstyleTask ->

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ test {
   }
 }
 check.dependsOn javadoc
+tasks.withType(Javadoc) {
+  options.addStringOption 'Xdoclint:-missing', '-quiet'
+}
 
 //// Checkstyle //////////////////////////////////////////////////
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ task shadowTest {
   dependsOn shadowJar
   def expected = new File("$projectDir/jar-footprint.txt")
   def report = new File("$reportsDir/shadowJarFootprint.txt")
-  inputs.file shadowJar.outputs
+  inputs.files shadowJar.outputs
   inputs.file expected
   outputs.file report
   doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,7 @@ task vanillaTest {
 
   def test = task("vanilla${jdk}Test", type: Test) {
     vanillaTest.dependsOn it
-    testClassesDir = sourceSets["vanilla${jdk}Test"].output.classesDir
+    testClassesDirs = sourceSets["vanilla${jdk}Test"].output.classesDirs
     classpath = sourceSets["vanilla${jdk}Test"].runtimeClasspath
     if (jdk == 9) {
       executable java9.java
@@ -348,7 +348,7 @@ task gwtTest(type: Test) {
   group = 'Verification'
   check.dependsOn it
   dependsOn compileGwtToJs
-  testClassesDir = sourceSets.gwtTest.output.classesDir
+  testClassesDirs = sourceSets.gwtTest.output.classesDirs
   classpath = sourceSets.gwtTest.runtimeClasspath
   reports {
     html {
@@ -415,7 +415,7 @@ task noGuavaTest {
 
   def test = task("noGuava${jdk}Test", type: Test) {
     noGuavaTest.dependsOn it
-    testClassesDir = sourceSets["noGuava${jdk}Test"].output.classesDir
+    testClassesDirs = sourceSets["noGuava${jdk}Test"].output.classesDirs
     classpath = sourceSets["noGuava${jdk}Test"].runtimeClasspath
     reports {
       html {
@@ -461,7 +461,7 @@ task noGuavaJ8Test(type: Test) {
   description 'Runs the no-guava-j8 integration tests.'
   group = 'Verification'
   check.dependsOn it
-  testClassesDir = sourceSets.noGuavaJ8Test.output.classesDir
+  testClassesDirs = sourceSets.noGuavaJ8Test.output.classesDirs
   classpath = sourceSets.noGuavaJ8Test.runtimeClasspath
   reports {
     html {
@@ -507,7 +507,7 @@ task("lambdaTest", type: Test) {
   description 'Runs the lambda integration tests.'
   group = 'Verification'
   check.dependsOn it
-  testClassesDir = sourceSets["lambdaTest"].output.classesDir
+  testClassesDirs = sourceSets["lambdaTest"].output.classesDirs
   classpath = sourceSets["lambdaTest"].runtimeClasspath
   reports {
     html {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
   id 'eclipse'
   id 'java'
   id 'com.bmuschko.nexus' version '2.3.1'
-  id 'com.github.johnrengelman.shadow' version '1.2.3'
+  id 'com.github.johnrengelman.shadow' version '2.0.2'
 }
 
 apply from: "gradle/travis-keep-alive.gradle"

--- a/gradle/travis-keep-alive.gradle
+++ b/gradle/travis-keep-alive.gradle
@@ -1,0 +1,12 @@
+// Print a bell to the terminal every time a test completes to stop Travis
+// killing us without spamming the log.
+apply plugin: 'java'
+
+if (System.env.TRAVIS == 'true') {
+  test {
+    afterTest { descriptor ->
+      print "\007"
+      out.flush()
+    }
+  }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 14 21:56:03 GMT 2016
+#Tue Jan 09 14:40:15 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip


### PR DESCRIPTION
We run basic tests against Java versions 6, 7, 8 and 9, but TravisCI has upgraded to Java 9.0.1, which triggers a known bug in Gradle 3.2. This PR contains a bunch of fixes to get us running smoothly in TravisCI on Gradle 4.4.1. Highlights:

* `travis_wait` is supposed to stop Travis killing our build if there's no output for five minutes. It appears to have stopped working. It worked by dumping visual bells to standard out, and has the annoying side-effect of preventing Travis live-updating logs as Gradle outputs them, so rather than attempt to fix it, we can just make Gradle dump out a bell every time a test finishes. This also means we time out sooner if Gradle actually freezes, and we won't die spuriously in future if we start taking >30m to run the tests.
* A bunch of random little things have changed in small ways. Painful to figure them out but they all end up looking pretty innocuous. Commit messages contain more details.
* During the Java 9 beta phase, we needed to pass in `--add-opens` for anything to work, due to changes in the way Java 9 did reflection security. Fortunately for everyone, the final release build made everything open by default, so we can just remove that now.